### PR TITLE
fix: use correct Miro API endpoint for GetFrameItems

### DIFF
--- a/miro/client_test.go
+++ b/miro/client_test.go
@@ -5239,8 +5239,11 @@ func TestGetFrameItems_Success(t *testing.T) {
 		if r.Method != http.MethodGet {
 			t.Errorf("expected GET, got %s", r.Method)
 		}
-		if !strings.HasPrefix(r.URL.Path, "/boards/board123/frames/frame456/items") {
-			t.Errorf("expected /boards/board123/frames/frame456/items, got %s", r.URL.Path)
+		if r.URL.Path != "/boards/board123/items" {
+			t.Errorf("expected /boards/board123/items, got %s", r.URL.Path)
+		}
+		if !strings.Contains(r.URL.RawQuery, "parent_item_id=frame456") {
+			t.Errorf("expected parent_item_id=frame456 in query, got %s", r.URL.RawQuery)
 		}
 
 		w.Header().Set("Content-Type", "application/json")

--- a/miro/frames.go
+++ b/miro/frames.go
@@ -204,8 +204,10 @@ func (c *Client) GetFrameItems(ctx context.Context, args GetFrameItemsArgs) (Get
 		limit = 100
 	}
 
-	// Use the specific frame items endpoint
-	path := fmt.Sprintf("/boards/%s/frames/%s/items?limit=%d", args.BoardID, args.FrameID, limit)
+	// Use the items endpoint with parent_item_id filter to get items within a frame.
+	// The /frames/{id}/items path does not exist in Miro API v2 and returns 404.
+	// See: https://developers.miro.com/reference/get-items-within-frame
+	path := fmt.Sprintf("/boards/%s/items?parent_item_id=%s&limit=%d", args.BoardID, args.FrameID, limit)
 	if args.Type != "" {
 		path += "&type=" + args.Type
 	}


### PR DESCRIPTION
## Summary

- `GetFrameItems` called `/boards/{id}/frames/{frame_id}/items` which does not exist in Miro API v2 and returns **404**
- Changed to use `/boards/{id}/items?parent_item_id={frame_id}` — the [documented endpoint](https://developers.miro.com/reference/get-items-within-frame) for retrieving items within a frame
- Updated test to verify the correct URL path and `parent_item_id` query parameter

## Test plan

- [x] All existing `TestGetFrameItems_*` tests pass (Success, ValidationErrors, WithCursor, WithTypeFilter)
- [x] Full test suite passes (`go test ./...`)
- [ ] Manual verification: call `miro_get_frame_items` against a real board with items inside a frame

Fixes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)