### PR TITLE
ci: add HOL skill-publish validate workflow

### DIFF
--- a/.github/workflows/hol-skill-validate.yml
+++ b/.github/workflows/hol-skill-validate.yml
@@ -1,0 +1,30 @@
+name: HOL Skill Validate
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    branches:
+      - main
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Validate Skill
+        uses: hashgraph-online/skill-publish@4d99459187151e4e55600741e3b4320ab66adfd2
+        with:
+          mode: validate
+          skill-dir: skills/miro-boards
+          annotate: "false"
+          preview-upload: "false"


### PR DESCRIPTION
This adds a small validate-only CI check for the existing skill metadata in this repo.

It only adds one workflow file, does not publish anything, and does not need secrets.

Why it looked like a fit here:
- MCP server for controlling Miro whiteboards with AI assistants
- Built-in tracing and metrics via mcp-otel-go (OTel Registry)

It runs schema and trust validation for `skills/miro-boards` and leaves runtime code, release flow, and publish credentials alone.
Permissions: read-only. No secrets. No publish. No runtime changes.

If you'd like it folded into an existing workflow or pointed at a different path, I can adjust the branch.