### PR TITLE
docs: record allowlist scope as MCP-handler-only (decision)

### DIFF
--- a/tools/share_allowlist.go
+++ b/tools/share_allowlist.go
@@ -7,6 +7,13 @@
 // guardrail: only emails whose domain matches the allowlist are permitted
 // through to the Miro API, regardless of what the agent was told to do.
 //
+// Scope: the allowlist enforces at the MCP handler boundary
+// (HandlerRegistry.ShareBoard). Direct callers of miro.Client.ShareBoard
+// (library consumers embedding the package) bypass it intentionally; the
+// threat model targets prompt-injected agents reaching the client through
+// the MCP transport, not human library consumers with their own trust
+// assumptions. See miro-mcp-server-032 for the recorded decision.
+//
 // See [miro-mcp-server-jyu] and the 22-04-2026 MCP portfolio security audit.
 package tools
 


### PR DESCRIPTION
## Summary

Closes [\`miro-mcp-server-032\`](.beads/issues.jsonl) (type: decision, P3).

The share-board allowlist introduced by \`06e7488\` (jyu) runs only at the MCP handler boundary. Direct callers of \`miro.Client.ShareBoard\` (library consumers embedding the package) bypass it intentionally — the threat model targets prompt-injected agents reaching the client through the MCP transport, not human library consumers.

## Decision (Option 1: MCP-handler-only)

This PR records that scope explicitly so the boundary doesn't get re-litigated as a bug later.

**Rationale:**
- Threat model: prompt-injected MCP agents, not embedding library consumers
- Library consumers have their own trust assumptions; forcing them through the env-var dependency would impose policy without consent
- The miro-mcp-server is currently the only library consumer; library-wide enforcement is defense against a hypothetical caller (YAGNI)
- Defense-in-depth still applies at the layer closest to the threat (MCP handler)

**Alternatives left on the table** (revisit if a future library consumer needs them):
- Option 2: move allowlist into the library
- Option 3: opt-in \`ShareAllowlist\` parameter on the client

## Changes

- \`tools/share_allowlist.go\`: add a \"Scope:\" paragraph to the package doc making the MCP-handler boundary explicit and pointing back to this bead

## Test plan

- [x] \`go build ./...\` succeeds
- [x] \`go test -race -failfast -run TestShareAllowlist ./tools/...\` passes
- [ ] Reviewer to confirm Option 1 is the right call (or push back with a concrete scenario for Option 2/3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)