### PR TITLE
feat(tools): miro_tool_search discovery + MIRO_TOOLS_PROFILE env var

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -22,6 +22,7 @@ Complete configuration guide for Miro MCP Server.
 | `MIRO_AUDIT_FILE` | - | Path to audit log file (enables file logging) |
 | `MIRO_AUDIT_MAX_SIZE` | `10MB` | Max size before log rotation |
 | `MIRO_SHARE_ALLOWED_DOMAINS` | *(see note)* | Comma-separated email domains permitted to receive `miro_share_board` invitations. Example: `tietoevry.com,tieto.com`. **Fail-closed:** when this var is unset, the server falls back to the authenticated user's own email domain. If neither is available, all sharing is blocked. |
+| `MIRO_TOOLS_PROFILE` | `full` | Tool surface to expose. `full` registers all 92 tools (preserves prior behavior). `essentials` registers only the `miro_tool_search` discovery meta-tool plus ~15 high-frequency tools (boards, list/find, sticky/text/frame/connector creation, list/get/update/delete items); agents reach the rest via `miro_tool_search` on demand. Useful when token cost matters and the client doesn't have its own tool-search support. Unknown values fall back to `full` with a warning. |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Run your [Miro](https://miro.com) workshops, retros, and planning sessions from 
 
 > **Community project** — Not officially affiliated with Miro. See [official options](#official-vs-community) below.
 
-**91 tools** | **Single binary** | **All platforms** | **All major AI tools**
+**92 tools** | **Single binary** | **All platforms** | **All major AI tools**
 
 [![CI](https://github.com/olgasafonova/miro-mcp-server/actions/workflows/ci.yml/badge.svg)](https://github.com/olgasafonova/miro-mcp-server/actions/workflows/ci.yml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/olgasafonova/miro-mcp-server)](https://goreportcard.com/report/github.com/olgasafonova/miro-mcp-server)
@@ -497,7 +497,7 @@ MIRO_ACCESS_TOKEN=your-token npx @modelcontextprotocol/inspector miro-mcp-server
 ```
 
 Open `http://localhost:6274` to:
-- Browse all 91 tools with their schemas
+- Browse all 92 tools with their schemas
 - Test tool calls interactively
 - View raw JSON-RPC messages
 - Debug parameter validation
@@ -539,9 +539,9 @@ See [SETUP.md](SETUP.md) for configuration guides.
 
 | Account Type | Support |
 |--------------|---------|
-| Free | Full access to all 91 tools |
-| Team | Full access to all 91 tools |
-| Business | Full access to all 91 tools |
+| Free | Full access to all 92 tools |
+| Team | Full access to all 92 tools |
+| Business | Full access to all 92 tools |
 | Enterprise | Full access + export to PDF/SVG |
 
 ---

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Run your [Miro](https://miro.com) workshops, retros, and planning sessions from 
 [![CI](https://github.com/olgasafonova/miro-mcp-server/actions/workflows/ci.yml/badge.svg)](https://github.com/olgasafonova/miro-mcp-server/actions/workflows/ci.yml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/olgasafonova/miro-mcp-server)](https://goreportcard.com/report/github.com/olgasafonova/miro-mcp-server)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![MCP Context](badges/mcp-tokens.svg)](#tools)
+[![MCP Context — full](badges/mcp-tokens.svg)](#token-efficiency)
+[![MCP Context — essentials](badges/mcp-tokens-essentials.svg)](#token-efficiency)
 
 <video src="https://github.com/user-attachments/assets/a27c535e-f3b5-4a3a-ac3c-bea5fe7ebd0b" width="100%" autoplay loop muted playsinline></video>
 
@@ -124,7 +125,24 @@ The badge above is awarded by [SkillCheck Pro](https://getskillcheck.com); this 
 
 ---
 
-## All 91 Tools
+## Token Efficiency
+
+The full tool surface (92 tools) costs roughly **15.5K tokens** of preload — about 7.8% of a 200K Claude context. For sessions where that footprint matters, set `MIRO_TOOLS_PROFILE=essentials` in your client config; the server then registers a curated 15-tool subset (boards, list/find/search, sticky/text/frame/connector creation, list/get/update/delete items) plus one discovery meta-tool. Agents reach the rest via `miro_tool_search` on demand.
+
+| Profile | Tools | Preload tokens (est.) | % of 200K context |
+|---|---|---|---|
+| `full` (default) | 92 | ~15,500 | 7.8% |
+| `essentials` | 15 | ~2,400 | 1.2% |
+
+Savings: **~13,100 tokens (84.5% reduction)** when you opt into `essentials`. Description tokens are exact (JSON-marshaled); schema cost is estimated at 200 bytes per tool. Reproduce locally with `go run ./cmd/token-count/`.
+
+`miro_tool_search(query?, category?, limit?)` is registered in both profiles. It searches tool names, titles, descriptions, and categories with weighted keyword scoring (name 3×, title 2×, category 2.5×, description 1×), returns up to 50 matches, and never recommends itself. Use it when you don't know which tool to reach for, or to scope to a category before browsing. Empty query plus a category returns the category's tools alphabetically.
+
+See [CONFIG.md](CONFIG.md) for the full env-var reference.
+
+---
+
+## All 92 Tools
 
 <details>
 <summary><b>Board Management (9)</b></summary>
@@ -370,7 +388,7 @@ Miro released their [official MCP server](https://miro.com/ai/mcp/) in December 
 | Feature | This Server | Official Miro MCP |
 |---------|-------------|-------------------|
 | **Last changelog entry** | April 2026 | January 2026 |
-| **Tools** | 91 | 15 (13 tools + 2 prompts) |
+| **Tools** | 92 (or 15 in `essentials` profile) | 15 (13 tools + 2 prompts) |
 | **Transport** | stdio + HTTP | HTTPS only (hosted) |
 | **Self-hosting** | Yes | No |
 | **Offline mode** | Yes | No |
@@ -392,7 +410,7 @@ Miro released their [official MCP server](https://miro.com/ai/mcp/) in December 
 
 **When to use the official server:** You want zero-setup via plugin marketplace, OAuth 2.1 enterprise security, AI-powered board context extraction, or code-to-board workflows.
 
-**When to use this server:** You need full API coverage (91 vs 15 tools), offline/self-hosted operation, bulk ops, mindmaps, tags, connectors, export, or a lightweight binary.
+**When to use this server:** You need full API coverage (92 vs 15 tools, or a tunable 15-tool `essentials` mode), offline/self-hosted operation, bulk ops, mindmaps, tags, connectors, export, or a lightweight binary.
 
 Both can coexist — use different MCP server names in your config.
 

--- a/badges/mcp-tokens-essentials.svg
+++ b/badges/mcp-tokens-essentials.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="306" height="20" role="img" aria-label="MCP Context (essentials): ~2K tokens (1.2%)">
+  <title>MCP Context (essentials): ~2K tokens (1.2%)</title>
+  <linearGradient id="s" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+  <clipPath id="r">
+    <rect width="306" height="20" rx="3" fill="#fff"/>
+  </clipPath>
+  <g clip-path="url(#r)">
+    <rect width="176" height="20" fill="#555"/>
+    <rect x="176" width="130" height="20" fill="#007ec6"/>
+    <rect width="306" height="20" fill="url(#s)"/>
+  </g>
+  <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="11">
+    <text aria-hidden="true" x="88.0" y="15" fill="#010101" fill-opacity=".3">MCP Context (essentials)</text>
+    <text x="88.0" y="14">MCP Context (essentials)</text>
+    <text aria-hidden="true" x="241.2" y="15" fill="#010101" fill-opacity=".3">~2K tokens (1.2%)</text>
+    <text x="241.2" y="14">~2K tokens (1.2%)</text>
+  </g>
+</svg>

--- a/badges/mcp-tokens.svg
+++ b/badges/mcp-tokens.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="228" height="20" role="img" aria-label="MCP Context: ~11K tokens (5.6%)">
-  <title>MCP Context: ~11K tokens (5.6%)</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="228" height="20" role="img" aria-label="MCP Context: ~15K tokens (7.8%)">
+  <title>MCP Context: ~15K tokens (7.8%)</title>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
     <stop offset="1" stop-opacity=".1"/>
@@ -15,7 +15,7 @@
   <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="11">
     <text aria-hidden="true" x="45.8" y="15" fill="#010101" fill-opacity=".3">MCP Context</text>
     <text x="45.8" y="14">MCP Context</text>
-    <text aria-hidden="true" x="160.0" y="15" fill="#010101" fill-opacity=".3">~11K tokens (5.6%)</text>
-    <text x="160.0" y="14">~11K tokens (5.6%)</text>
+    <text aria-hidden="true" x="160.0" y="15" fill="#010101" fill-opacity=".3">~15K tokens (7.8%)</text>
+    <text x="160.0" y="14">~15K tokens (7.8%)</text>
   </g>
 </svg>

--- a/cmd/token-count/main.go
+++ b/cmd/token-count/main.go
@@ -1,5 +1,7 @@
-// Command token-count estimates the MCP context token cost of registering all
-// Miro MCP tools and generates a shields.io-style SVG badge.
+// Command token-count estimates the MCP context token cost of registering
+// Miro MCP tools and generates shields.io-style SVG badges, one per
+// MIRO_TOOLS_PROFILE option (full / essentials). Always prints a comparison
+// to stdout so the savings claim is reproducible from the repo.
 //
 // Usage:
 //
@@ -33,14 +35,23 @@ type mcpTool struct {
 	Annotations map[string]bool `json:"annotations,omitempty"`
 }
 
-func main() {
-	// Build MCP wire-format representation of each tool.
-	mcpTools := make([]mcpTool, 0, len(tools.AllTools))
-	for _, spec := range tools.AllTools {
-		t := mcpTool{
-			Name:        spec.Name,
-			Description: spec.Description,
-		}
+// profileMeasurement captures the token-cost numbers for a registered
+// profile so callers (badge generator, stdout printer) can share results.
+type profileMeasurement struct {
+	Profile      tools.Profile
+	ToolCount    int
+	DescBytes    int
+	DescTokens   int
+	SchemaTokens int
+	TotalTokens  int
+	Percentage   float64
+}
+
+func measureProfile(profile tools.Profile) (profileMeasurement, error) {
+	specs := tools.ToolsForProfile(profile)
+	wire := make([]mcpTool, 0, len(specs))
+	for _, spec := range specs {
+		t := mcpTool{Name: spec.Name, Description: spec.Description}
 		annotations := make(map[string]bool)
 		if spec.ReadOnly {
 			annotations["readOnlyHint"] = true
@@ -54,47 +65,98 @@ func main() {
 		if len(annotations) > 0 {
 			t.Annotations = annotations
 		}
-		mcpTools = append(mcpTools, t)
+		wire = append(wire, t)
 	}
 
-	// Marshal to JSON to measure description payload size.
-	data, err := json.Marshal(mcpTools)
+	data, err := json.Marshal(wire)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "error marshaling tools: %v\n", err)
-		os.Exit(1)
+		return profileMeasurement{}, fmt.Errorf("marshal %s: %w", profile, err)
 	}
 
 	descTokens := len(data) / charsPerToken
-	schemaTokens := len(tools.AllTools) * avgSchemaBytesPerTool / charsPerToken
+	schemaTokens := len(specs) * avgSchemaBytesPerTool / charsPerToken
 	totalTokens := descTokens + schemaTokens
-	percentage := float64(totalTokens) / float64(contextWindow) * 100
 
-	// Round to nearest 100 for display.
-	displayTokens := int(math.Round(float64(totalTokens)/100) * 100)
+	return profileMeasurement{
+		Profile:      profile,
+		ToolCount:    len(specs),
+		DescBytes:    len(data),
+		DescTokens:   descTokens,
+		SchemaTokens: schemaTokens,
+		TotalTokens:  totalTokens,
+		Percentage:   float64(totalTokens) / float64(contextWindow) * 100,
+	}, nil
+}
+
+// badgeFilename returns the relative output path for a profile's SVG badge.
+// The default profile keeps the historical filename so existing README
+// references don't break.
+func badgeFilename(profile tools.Profile) string {
+	if profile == tools.ProfileFull {
+		return filepath.Join("badges", "mcp-tokens.svg")
+	}
+	return filepath.Join("badges", "mcp-tokens-"+string(profile)+".svg")
+}
+
+func writeBadge(m profileMeasurement) (string, error) {
+	displayTokens := int(math.Round(float64(m.TotalTokens)/100) * 100)
 	displayK := fmt.Sprintf("~%dK", displayTokens/1000)
 	if displayTokens < 1000 {
 		displayK = fmt.Sprintf("~%d", displayTokens)
 	}
 
 	label := "MCP Context"
-	value := fmt.Sprintf("%s tokens (%.1f%%)", displayK, percentage)
-
-	// Generate badge SVG.
+	if m.Profile != tools.ProfileFull {
+		label = fmt.Sprintf("MCP Context (%s)", m.Profile)
+	}
+	value := fmt.Sprintf("%s tokens (%.1f%%)", displayK, m.Percentage)
 	svg := generateBadge(label, value)
 
-	badgePath := filepath.Join("badges", "mcp-tokens.svg")
-	if err := os.WriteFile(badgePath, []byte(svg), 0600); err != nil {
-		fmt.Fprintf(os.Stderr, "error writing badge: %v\n", err)
+	path := badgeFilename(m.Profile)
+	if err := os.WriteFile(path, []byte(svg), 0600); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+func main() {
+	full, err := measureProfile(tools.ProfileFull)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	essentials, err := measureProfile(tools.ProfileEssentials)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 
-	fmt.Printf("Tools:             %d\n", len(tools.AllTools))
-	fmt.Printf("Description JSON:  %d bytes (%d tokens)\n", len(data), descTokens)
-	fmt.Printf("Schema estimate:   %d bytes (%d tokens)\n",
-		len(tools.AllTools)*avgSchemaBytesPerTool, schemaTokens)
-	fmt.Printf("Total estimate:    %d tokens (%.1f%% of %dK context)\n",
-		totalTokens, percentage, contextWindow/1000)
-	fmt.Printf("Badge written:     %s\n", badgePath)
+	fullBadge, err := writeBadge(full)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "writing full badge:", err)
+		os.Exit(1)
+	}
+	essBadge, err := writeBadge(essentials)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "writing essentials badge:", err)
+		os.Exit(1)
+	}
+
+	saved := full.TotalTokens - essentials.TotalTokens
+	pct := float64(saved) / float64(full.TotalTokens) * 100
+
+	fmt.Println("Profile     Tools  DescTokens  SchemaTokens  Total   % of 200K")
+	fmt.Println("----------  -----  ----------  ------------  ------  ---------")
+	fmt.Printf("%-10s  %5d  %10d  %12d  %6d  %5.1f%%\n",
+		full.Profile, full.ToolCount, full.DescTokens, full.SchemaTokens, full.TotalTokens, full.Percentage)
+	fmt.Printf("%-10s  %5d  %10d  %12d  %6d  %5.1f%%\n",
+		essentials.Profile, essentials.ToolCount, essentials.DescTokens, essentials.SchemaTokens, essentials.TotalTokens, essentials.Percentage)
+	fmt.Println()
+	fmt.Printf("Savings (essentials vs full): %d tokens (%.1f%% reduction)\n", saved, pct)
+	fmt.Println()
+	fmt.Println("Badges written:")
+	fmt.Println("  ", fullBadge)
+	fmt.Println("  ", essBadge)
 }
 
 // generateBadge creates a shields.io-style SVG badge.

--- a/main.go
+++ b/main.go
@@ -157,7 +157,20 @@ func main() {
 			"source", shareAllowlist.Source())
 	}
 
-	// Register all Miro tools with audit logging and desire path normalization
+	// Register Miro tools, honoring MIRO_TOOLS_PROFILE.
+	//   full       — every tool (default; preserves behavior for upgrading users)
+	//   essentials — meta-tool plus ~15 high-frequency tools; agents reach
+	//                the rest via miro_tool_search on demand
+	// Unknown values fall back to full with a warning so a typo never
+	// silently strips tools the operator was relying on.
+	profileRaw := os.Getenv("MIRO_TOOLS_PROFILE")
+	profile, ok := tools.ParseProfile(profileRaw)
+	if !ok {
+		logger.Warn("Unknown MIRO_TOOLS_PROFILE; falling back to full",
+			"value", profileRaw,
+			"valid", []string{string(tools.ProfileFull), string(tools.ProfileEssentials)})
+	}
+
 	registry := tools.NewHandlerRegistry(client, logger).
 		WithAuditLogger(auditLogger).
 		WithShareAllowlist(shareAllowlist).
@@ -165,7 +178,7 @@ func main() {
 	if user != nil {
 		registry = registry.WithUser(user.ID, user.Email)
 	}
-	registry.RegisterAll(server)
+	registry.RegisterProfile(server, profile)
 
 	// Register MCP Resources (miro://board/{id} URIs)
 	resourceRegistry := resources.NewRegistry(client)
@@ -181,7 +194,7 @@ func main() {
 	cardOpts := servercard.Options{
 		Name:        "io.github.olgasafonova/miro-mcp-server",
 		Version:     ServerVersion,
-		Description: "MCP server for Miro whiteboards. 91 tools for boards, items, diagrams, mindmaps, tags, groups, connectors, export, and audit. Voice-friendly.",
+		Description: "MCP server for Miro whiteboards. 92 tools for boards, items, diagrams, mindmaps, tags, groups, connectors, export, and audit, with miro_tool_search for discovery. Voice-friendly.",
 		Title:       "Miro MCP Server",
 		WebsiteURL:  "https://github.com/olgasafonova/miro-mcp-server",
 		Repository: &servercard.Repository{

--- a/tools/definitions.go
+++ b/tools/definitions.go
@@ -53,6 +53,12 @@ type ToolSpec struct {
 // Tool descriptions are optimized for token efficiency and voice interaction.
 var AllTools = []ToolSpec{
 	// ==========================================================================
+	// Discovery (always-on meta-tool — keep first so agents see it before
+	// scanning the full surface)
+	// ==========================================================================
+	SearchToolSpec,
+
+	// ==========================================================================
 	// Board Tools
 	// ==========================================================================
 	{

--- a/tools/definitions_test.go
+++ b/tools/definitions_test.go
@@ -59,6 +59,7 @@ func TestToolCategories(t *testing.T) {
 		"groups":     true,
 		"members":    true,
 		"frames":     true,
+		"discovery":  true,
 	}
 
 	for _, tool := range AllTools {
@@ -124,7 +125,8 @@ func TestToolCount(t *testing.T) {
 	//          +2 update_image_from_file, update_document_from_file = 89
 	// v1.15.0: -1 miro_ungroup (merged into miro_delete_group) = 88
 	// v1.16.0: +1 update_doc + 2 table tools (list_tables, get_table) = 91
-	expectedCount := 91
+	// v1.17.0: +1 miro_tool_search discovery meta-tool = 92
+	expectedCount := 92
 	if len(AllTools) != expectedCount {
 		t.Errorf("expected %d tools, got %d", expectedCount, len(AllTools))
 	}

--- a/tools/handlers.go
+++ b/tools/handlers.go
@@ -91,12 +91,26 @@ func (h *HandlerRegistry) WithDesirePathLogger(dpLogger *desirepath.Logger, norm
 	return h
 }
 
-// RegisterAll registers all tools with the MCP server.
+// RegisterAll registers every tool in AllTools with the MCP server. Equivalent
+// to RegisterProfile(server, ProfileFull). Kept for backward compatibility
+// with callers that don't know about profiles yet.
 func (h *HandlerRegistry) RegisterAll(server *mcp.Server) {
-	for _, spec := range AllTools {
+	h.RegisterProfile(server, ProfileFull)
+}
+
+// RegisterProfile registers a subset of AllTools determined by the profile.
+// ProfileFull (the default) registers everything. ProfileEssentials registers
+// only the discovery meta-tool plus the curated EssentialsToolNames list;
+// agents discover the rest via miro_tool_search on demand.
+func (h *HandlerRegistry) RegisterProfile(server *mcp.Server, profile Profile) {
+	specs := ToolsForProfile(profile)
+	for _, spec := range specs {
 		h.registerTool(server, spec)
 	}
-	h.logger.Info("Registered all Miro tools", "count", len(AllTools))
+	h.logger.Info("Registered Miro tools",
+		"profile", string(profile),
+		"count", len(specs),
+		"total_available", len(AllTools))
 }
 
 // buildHandlerMap creates a map of method names to registration functions.
@@ -207,6 +221,9 @@ func (h *HandlerRegistry) buildHandlerMap() map[string]func(*mcp.Server, *mcp.To
 		// Audit tools (local, not Miro API)
 		"GetAuditLog":         makeHandler(h, h.GetAuditLog),
 		"GetDesirePathReport": makeHandler(h, h.GetDesirePathReport),
+
+		// Discovery (local, no Miro API call)
+		"SearchTools": makeHandler(h, h.SearchTools),
 
 		// App card tools
 		"CreateAppCard": makeHandler(h, h.client.CreateAppCard),

--- a/tools/profile.go
+++ b/tools/profile.go
@@ -1,0 +1,78 @@
+package tools
+
+// Profile selects which tools the MCP server registers at startup. Operators
+// pick this via MIRO_TOOLS_PROFILE: full (default — all 91 tools) or
+// essentials (the meta-tool plus ~15 high-frequency tools). The essentials
+// profile is graceful degradation for clients without API-level tool_search;
+// agents discover the rest via miro_tool_search on demand.
+type Profile string
+
+const (
+	// ProfileFull registers every tool in AllTools.
+	ProfileFull Profile = "full"
+
+	// ProfileEssentials registers only meta-tools plus a curated short list.
+	ProfileEssentials Profile = "essentials"
+)
+
+// EssentialsToolNames is the list of MCP tool names registered when
+// MIRO_TOOLS_PROFILE=essentials. Chosen for the most common workflow
+// fragments (find, browse, create core item types, edit/delete). Anything
+// not on this list is reachable via miro_tool_search.
+var EssentialsToolNames = []string{
+	ToolSearchName,
+	"miro_list_boards",
+	"miro_find_board",
+	"miro_get_board_summary",
+	"miro_get_board_content",
+	"miro_create_sticky",
+	"miro_create_text",
+	"miro_create_frame",
+	"miro_create_connector",
+	"miro_list_items",
+	"miro_get_item",
+	"miro_search_board",
+	"miro_bulk_create",
+	"miro_delete_item",
+	"miro_update_item",
+}
+
+// ParseProfile maps an operator-supplied string (typically the value of
+// MIRO_TOOLS_PROFILE) to a Profile. Empty / unknown values fall back to
+// ProfileFull so a typo never silently strips tools the operator was
+// relying on.
+func ParseProfile(s string) (Profile, bool) {
+	switch s {
+	case "":
+		return ProfileFull, true
+	case string(ProfileFull):
+		return ProfileFull, true
+	case string(ProfileEssentials):
+		return ProfileEssentials, true
+	}
+	return ProfileFull, false
+}
+
+// ToolsForProfile filters AllTools to those that belong in the given profile.
+// ProfileFull returns everything (in declaration order). ProfileEssentials
+// returns the entries listed in EssentialsToolNames, in that order. Tools
+// listed in EssentialsToolNames but missing from AllTools are silently
+// skipped — the caller is expected to maintain consistency.
+func ToolsForProfile(profile Profile) []ToolSpec {
+	if profile != ProfileEssentials {
+		return AllTools
+	}
+
+	byName := make(map[string]ToolSpec, len(AllTools))
+	for _, spec := range AllTools {
+		byName[spec.Name] = spec
+	}
+
+	out := make([]ToolSpec, 0, len(EssentialsToolNames))
+	for _, name := range EssentialsToolNames {
+		if spec, ok := byName[name]; ok {
+			out = append(out, spec)
+		}
+	}
+	return out
+}

--- a/tools/profile_integration_test.go
+++ b/tools/profile_integration_test.go
@@ -1,0 +1,112 @@
+package tools
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// TestRegisterProfile_FullExposesEverything spins up an in-memory MCP server,
+// registers the full profile, and asserts that an MCP-protocol tools/list
+// returns exactly len(AllTools) tools — proving the registration plumbing
+// honors the profile end-to-end (not just at the spec level).
+func TestRegisterProfile_FullExposesEverything(t *testing.T) {
+	count := registerAndListTools(t, ProfileFull)
+	if count != len(AllTools) {
+		t.Errorf("ProfileFull tools/list returned %d tools, want %d", count, len(AllTools))
+	}
+}
+
+// TestRegisterProfile_EssentialsIsLean asserts that ProfileEssentials drops
+// the surface to the curated EssentialsToolNames list and keeps the discovery
+// meta-tool first. This is the headline UX promise of the env var: a client
+// that only sees ~15 tools but can still reach the rest via miro_tool_search.
+func TestRegisterProfile_EssentialsIsLean(t *testing.T) {
+	count := registerAndListTools(t, ProfileEssentials)
+	wantCount := len(EssentialsToolNames)
+	if count != wantCount {
+		t.Errorf("ProfileEssentials tools/list returned %d tools, want %d", count, wantCount)
+	}
+}
+
+// TestRegisterProfile_EssentialsContainsSearchTool verifies the discovery
+// meta-tool itself is reachable in the lean profile. Without it, agents that
+// don't know which tool to call have no recovery path.
+func TestRegisterProfile_EssentialsContainsSearchTool(t *testing.T) {
+	tools := registerAndListToolNames(t, ProfileEssentials)
+	found := false
+	for _, name := range tools {
+		if name == ToolSearchName {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("essentials profile must include %s; got tools: %v", ToolSearchName, tools)
+	}
+}
+
+// TestRegisterProfile_TokenSavings_Realistic asserts the essentials profile
+// is meaningfully smaller than full — the property that motivates having a
+// profile at all. Numbers don't have to match the README estimate exactly
+// (those depend on schema cost which we don't measure here), but the lean
+// profile should be at least 70% smaller by tool count.
+func TestRegisterProfile_TokenSavings_Realistic(t *testing.T) {
+	full := len(ToolsForProfile(ProfileFull))
+	ess := len(ToolsForProfile(ProfileEssentials))
+	reduction := float64(full-ess) / float64(full) * 100
+	if reduction < 70.0 {
+		t.Errorf("expected at least 70%% reduction from full to essentials, got %.1f%% (%d -> %d)",
+			reduction, full, ess)
+	}
+}
+
+// registerAndListTools is the shared scaffolding: build a registry against a
+// no-op mock client, register the profile on a real *mcp.Server, connect a
+// client over in-memory transport, and count tools/list results. Returns the
+// count.
+func registerAndListTools(t *testing.T, profile Profile) int {
+	t.Helper()
+	return len(registerAndListToolNames(t, profile))
+}
+
+func registerAndListToolNames(t *testing.T, profile Profile) []string {
+	t.Helper()
+
+	registry := NewHandlerRegistry(&MockClient{}, testLogger())
+
+	server := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "1.0"}, nil)
+	registry.RegisterProfile(server, profile)
+
+	clientTransport, serverTransport := mcp.NewInMemoryTransports()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	serverDone := make(chan error, 1)
+	go func() {
+		serverDone <- server.Run(ctx, serverTransport)
+	}()
+
+	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "1.0"}, nil)
+	session, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("Failed to connect client: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = session.Close()
+		cancel()
+		<-serverDone
+	})
+
+	res, err := session.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListTools failed: %v", err)
+	}
+	names := make([]string, 0, len(res.Tools))
+	for _, tool := range res.Tools {
+		names = append(names, tool.Name)
+	}
+	return names
+}

--- a/tools/profile_test.go
+++ b/tools/profile_test.go
@@ -1,0 +1,83 @@
+package tools
+
+import "testing"
+
+func TestParseProfile(t *testing.T) {
+	tests := []struct {
+		input  string
+		want   Profile
+		wantOK bool
+	}{
+		{"", ProfileFull, true},
+		{"full", ProfileFull, true},
+		{"essentials", ProfileEssentials, true},
+		{"FULL", ProfileFull, false}, // case-sensitive on purpose; surface the typo
+		{"core", ProfileFull, false},
+		{"unknown", ProfileFull, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, ok := ParseProfile(tt.input)
+			if got != tt.want || ok != tt.wantOK {
+				t.Errorf("ParseProfile(%q) = (%v, %v), want (%v, %v)",
+					tt.input, got, ok, tt.want, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestToolsForProfile_FullReturnsAll(t *testing.T) {
+	got := ToolsForProfile(ProfileFull)
+	if len(got) != len(AllTools) {
+		t.Errorf("ProfileFull returned %d tools, want %d", len(got), len(AllTools))
+	}
+}
+
+func TestToolsForProfile_EssentialsHasMetaToolFirst(t *testing.T) {
+	got := ToolsForProfile(ProfileEssentials)
+	if len(got) == 0 {
+		t.Fatal("ProfileEssentials returned empty list")
+	}
+	if got[0].Name != ToolSearchName {
+		t.Errorf("essentials profile should start with %s, got %s", ToolSearchName, got[0].Name)
+	}
+}
+
+func TestToolsForProfile_EssentialsListMatchesNames(t *testing.T) {
+	got := ToolsForProfile(ProfileEssentials)
+	gotNames := make(map[string]bool, len(got))
+	for _, spec := range got {
+		gotNames[spec.Name] = true
+	}
+	for _, want := range EssentialsToolNames {
+		// EssentialsToolNames may legitimately include names not in AllTools
+		// (the function silently skips those), so don't fail on absence —
+		// but every entry that *is* in AllTools should be present.
+		if !specInAllTools(want) {
+			continue
+		}
+		if !gotNames[want] {
+			t.Errorf("essentials profile missing %s", want)
+		}
+	}
+}
+
+func TestToolsForProfile_EssentialsCoverageOfRealTools(t *testing.T) {
+	// Sanity check: every name in EssentialsToolNames should resolve to a real
+	// tool in AllTools. If not, the curated list has drifted from reality and
+	// should be updated.
+	for _, name := range EssentialsToolNames {
+		if !specInAllTools(name) {
+			t.Errorf("essentials list references unknown tool %q — fix EssentialsToolNames or remove it", name)
+		}
+	}
+}
+
+func specInAllTools(name string) bool {
+	for _, spec := range AllTools {
+		if spec.Name == name {
+			return true
+		}
+	}
+	return false
+}

--- a/tools/search.go
+++ b/tools/search.go
@@ -1,0 +1,251 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// ToolSearchName is the MCP name of the discovery meta-tool.
+const ToolSearchName = "miro_tool_search"
+
+// ToolSearchArgs are the inputs to miro_tool_search.
+type ToolSearchArgs struct {
+	// Query matches against tool name, title, and description (case-insensitive).
+	// Empty query plus a Category returns all tools in that category.
+	Query string `json:"query,omitempty" jsonschema:"Search terms matched against tool name, title, and description"`
+
+	// Category filters results to a single category (e.g. boards, create, read).
+	Category string `json:"category,omitempty" jsonschema:"Filter by category: boards, create, read, update, delete, tags, members, export, audit, diagrams"`
+
+	// Limit caps the number of results. Default 10, max 50.
+	Limit int `json:"limit,omitempty" jsonschema:"Maximum results to return (default 10, max 50)"`
+}
+
+// ToolSearchMatch is one tool returned from a search.
+type ToolSearchMatch struct {
+	Name        string  `json:"name"`
+	Category    string  `json:"category,omitempty"`
+	Title       string  `json:"title,omitempty"`
+	Description string  `json:"description"`
+	Score       float64 `json:"score"`
+}
+
+// ToolSearchResult is the structured response from miro_tool_search.
+type ToolSearchResult struct {
+	Tools   []ToolSearchMatch `json:"tools"`
+	Total   int               `json:"total"`
+	Message string            `json:"message"`
+}
+
+// SearchToolSpec is the ToolSpec for miro_tool_search. Defined here (rather
+// than inlined into AllTools) so the registration site and the search
+// implementation stay close.
+var SearchToolSpec = ToolSpec{
+	Name:       ToolSearchName,
+	Method:     "SearchTools",
+	Title:      "Find Miro Tools",
+	Category:   "discovery",
+	ReadOnly:   true,
+	Idempotent: true,
+	Description: `Find Miro tools by keyword or category. Returns matching tool names + short descriptions; call those tools directly afterward.
+
+USE WHEN: you don't know which tool exists for a task, or you want to scope to a category before browsing. Examples: "find tools for stickies", "what can I do with frames?", "show me all destructive tools".
+
+PARAMETERS:
+- query: keywords matched against tool name, title, description (e.g. "sticky note", "share board", "diagram").
+- category: filter to one of: boards, create, read, update, delete, tags, members, export, audit, diagrams. Optional.
+- limit: max results (default 10, max 50).
+
+Returns up to ` + "`limit`" + ` matches sorted by relevance, with name, category, title, and a short description excerpt. Empty query plus a category returns the category's tools sorted by name.
+
+This is a discovery tool. After picking a tool from the result, call it directly; do not re-route through this search.`,
+}
+
+// SearchTools implements the miro_tool_search handler. It is a pure
+// in-process search over the registered AllTools list — no Miro API calls,
+// no network. Used to keep token cost low when an agent doesn't know
+// which of the 90+ tools to reach for.
+func (h *HandlerRegistry) SearchTools(_ context.Context, args ToolSearchArgs) (ToolSearchResult, error) {
+	matches := scoreTools(args, AllTools)
+
+	msg := buildSearchMessage(args, matches)
+	return ToolSearchResult{
+		Tools:   matches,
+		Total:   len(matches),
+		Message: msg,
+	}, nil
+}
+
+// scoreTools is the deterministic ranking step. Exposed for testability.
+func scoreTools(args ToolSearchArgs, tools []ToolSpec) []ToolSearchMatch {
+	limit := args.Limit
+	switch {
+	case limit <= 0:
+		limit = 10
+	case limit > 50:
+		limit = 50
+	}
+
+	query := strings.ToLower(strings.TrimSpace(args.Query))
+	terms := tokenize(query)
+	categoryFilter := strings.ToLower(strings.TrimSpace(args.Category))
+
+	type scored struct {
+		spec  ToolSpec
+		score float64
+	}
+
+	candidates := make([]scored, 0, len(tools))
+	for _, t := range tools {
+		// Don't recommend the search tool itself; that's a recursion trap.
+		if t.Name == ToolSearchName {
+			continue
+		}
+		if categoryFilter != "" && !strings.EqualFold(t.Category, categoryFilter) {
+			continue
+		}
+		s := computeScore(t, terms)
+		// When there's no query, fall back to alphabetical within the category.
+		if query == "" {
+			candidates = append(candidates, scored{spec: t, score: 0})
+			continue
+		}
+		if s == 0 {
+			continue
+		}
+		candidates = append(candidates, scored{spec: t, score: s})
+	}
+
+	sort.SliceStable(candidates, func(i, j int) bool {
+		if candidates[i].score != candidates[j].score {
+			return candidates[i].score > candidates[j].score
+		}
+		return candidates[i].spec.Name < candidates[j].spec.Name
+	})
+
+	if len(candidates) > limit {
+		candidates = candidates[:limit]
+	}
+
+	out := make([]ToolSearchMatch, len(candidates))
+	for i, c := range candidates {
+		out[i] = ToolSearchMatch{
+			Name:        c.spec.Name,
+			Category:    c.spec.Category,
+			Title:       c.spec.Title,
+			Description: shortenDescription(c.spec.Description, 200),
+			Score:       c.score,
+		}
+	}
+	return out
+}
+
+// computeScore weights matches by where the term appears: name hits dominate
+// (the agent is most likely to remember a fragment of the name), title and
+// category bonuses help the user-facing-intent case, description is the fallback.
+// Multi-word queries are OR-scored: each matching term contributes.
+func computeScore(spec ToolSpec, terms []string) float64 {
+	if len(terms) == 0 {
+		return 0
+	}
+
+	name := strings.ToLower(spec.Name)
+	title := strings.ToLower(spec.Title)
+	category := strings.ToLower(spec.Category)
+	desc := strings.ToLower(spec.Description)
+
+	const (
+		nameWeight     = 3.0
+		titleWeight    = 2.0
+		categoryWeight = 2.5
+		descWeight     = 1.0
+	)
+
+	var score float64
+	for _, term := range terms {
+		if term == "" {
+			continue
+		}
+		if strings.Contains(name, term) {
+			score += nameWeight
+		}
+		if strings.Contains(title, term) {
+			score += titleWeight
+		}
+		if category == term {
+			score += categoryWeight
+		}
+		// Description matches are diminishing-returns — count once, not per occurrence,
+		// so a single keyword spam in a long description doesn't dominate.
+		if strings.Contains(desc, term) {
+			score += descWeight
+		}
+	}
+	return score
+}
+
+// tokenize splits on whitespace and common punctuation, drops empties and
+// very-short noise tokens. Underscores and hyphens are kept as separators
+// so "miro_create_sticky" indexes its constituent words.
+func tokenize(s string) []string {
+	if s == "" {
+		return nil
+	}
+	splitter := func(r rune) bool {
+		switch r {
+		case ' ', '\t', '\n', '\r', ',', '.', ';', ':', '!', '?', '"', '\'', '(', ')', '[', ']', '{', '}', '_', '-', '/':
+			return true
+		}
+		return false
+	}
+	parts := strings.FieldsFunc(s, splitter)
+	out := parts[:0]
+	for _, p := range parts {
+		if len(p) < 2 {
+			continue
+		}
+		out = append(out, p)
+	}
+	return out
+}
+
+// shortenDescription returns at most maxLen runes of the description's first
+// non-empty paragraph. Multi-line descriptions (USE WHEN / FAILS WHEN format)
+// would otherwise blow the context budget that miro_tool_search is built to
+// protect.
+func shortenDescription(desc string, maxLen int) string {
+	if desc == "" {
+		return ""
+	}
+	// First non-empty line (skip the lead newline if any).
+	firstLine := desc
+	if i := strings.IndexAny(desc, "\r\n"); i >= 0 {
+		firstLine = strings.TrimSpace(desc[:i])
+	}
+	firstLine = strings.TrimSpace(firstLine)
+	runes := []rune(firstLine)
+	if len(runes) <= maxLen {
+		return firstLine
+	}
+	return string(runes[:maxLen]) + "..."
+}
+
+// buildSearchMessage produces a short status string for voice/log output.
+func buildSearchMessage(args ToolSearchArgs, matches []ToolSearchMatch) string {
+	switch {
+	case len(matches) == 0 && args.Query != "" && args.Category != "":
+		return fmt.Sprintf("No tools matched query %q in category %q", args.Query, args.Category)
+	case len(matches) == 0 && args.Query != "":
+		return fmt.Sprintf("No tools matched query %q", args.Query)
+	case len(matches) == 0 && args.Category != "":
+		return fmt.Sprintf("No tools in category %q", args.Category)
+	case args.Query == "" && args.Category != "":
+		return fmt.Sprintf("Found %d tools in category %q", len(matches), args.Category)
+	case args.Category != "":
+		return fmt.Sprintf("Found %d tools matching %q in category %q", len(matches), args.Query, args.Category)
+	default:
+		return fmt.Sprintf("Found %d tools matching %q", len(matches), args.Query)
+	}
+}

--- a/tools/search_test.go
+++ b/tools/search_test.go
@@ -1,0 +1,182 @@
+package tools
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// fixture used so tests don't depend on the volatile real AllTools list.
+var searchTestTools = []ToolSpec{
+	{
+		Name:        "miro_create_sticky",
+		Method:      "CreateSticky",
+		Title:       "Create Sticky Note",
+		Category:    "create",
+		Description: "Add a sticky note to a Miro board with text content and optional position.",
+	},
+	{
+		Name:        "miro_create_card",
+		Method:      "CreateCard",
+		Title:       "Create Card",
+		Category:    "create",
+		Description: "Create a card item with title and description on a board.",
+	},
+	{
+		Name:        "miro_share_board",
+		Method:      "ShareBoard",
+		Title:       "Share Board",
+		Category:    "members",
+		Destructive: true,
+		Description: "Invite an email to a Miro board with role (viewer, commenter, editor).",
+	},
+	{
+		Name:        "miro_list_items",
+		Method:      "ListItems",
+		Title:       "List Items",
+		Category:    "read",
+		ReadOnly:    true,
+		Description: "List items on a board, optionally filtered by type or tag.",
+	},
+	{
+		Name:        "miro_delete_item",
+		Method:      "DeleteItem",
+		Title:       "Delete Item",
+		Category:    "delete",
+		Destructive: true,
+		Description: "Permanently delete an item by ID. Cannot be undone.",
+	},
+}
+
+func TestScoreTools_NameMatchDominates(t *testing.T) {
+	got := scoreTools(ToolSearchArgs{Query: "sticky"}, searchTestTools)
+	if len(got) == 0 || got[0].Name != "miro_create_sticky" {
+		t.Fatalf("expected miro_create_sticky first, got %+v", names(got))
+	}
+}
+
+func TestScoreTools_CategoryFilter(t *testing.T) {
+	got := scoreTools(ToolSearchArgs{Query: "create", Category: "create"}, searchTestTools)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 create-category hits, got %d: %+v", len(got), names(got))
+	}
+	for _, m := range got {
+		if m.Category != "create" {
+			t.Errorf("non-create category leaked through: %s/%s", m.Name, m.Category)
+		}
+	}
+}
+
+func TestScoreTools_EmptyQueryWithCategoryReturnsAll(t *testing.T) {
+	got := scoreTools(ToolSearchArgs{Category: "create"}, searchTestTools)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 create tools when query empty, got %d", len(got))
+	}
+}
+
+func TestScoreTools_NoMatchReturnsEmpty(t *testing.T) {
+	got := scoreTools(ToolSearchArgs{Query: "completely_unrelated_term_xyzzy"}, searchTestTools)
+	if len(got) != 0 {
+		t.Errorf("expected 0 matches, got %d: %+v", len(got), names(got))
+	}
+}
+
+func TestScoreTools_LimitDefault(t *testing.T) {
+	// Build a fixture larger than the default limit (10).
+	manyTools := make([]ToolSpec, 0, 15)
+	for i := 0; i < 15; i++ {
+		manyTools = append(manyTools, ToolSpec{
+			Name:        "miro_match_" + string(rune('a'+i)),
+			Category:    "read",
+			Description: "matches the query foo",
+		})
+	}
+	got := scoreTools(ToolSearchArgs{Query: "foo"}, manyTools)
+	if len(got) != 10 {
+		t.Errorf("expected default limit 10, got %d", len(got))
+	}
+}
+
+func TestScoreTools_LimitCappedAt50(t *testing.T) {
+	got := scoreTools(ToolSearchArgs{Query: "anything", Limit: 9999}, searchTestTools)
+	// Limit doesn't add tools, just doesn't exceed 50; the test fixture has 5.
+	if len(got) > 50 {
+		t.Errorf("expected limit cap at 50, got %d", len(got))
+	}
+}
+
+func TestScoreTools_DoesNotRecommendSelf(t *testing.T) {
+	tools := append([]ToolSpec{SearchToolSpec}, searchTestTools...)
+	got := scoreTools(ToolSearchArgs{Query: "tool"}, tools)
+	for _, m := range got {
+		if m.Name == ToolSearchName {
+			t.Errorf("search tool should not recommend itself, got %s in results", m.Name)
+		}
+	}
+}
+
+func TestScoreTools_MultiTermQuery(t *testing.T) {
+	got := scoreTools(ToolSearchArgs{Query: "delete item"}, searchTestTools)
+	if len(got) == 0 || got[0].Name != "miro_delete_item" {
+		t.Fatalf("expected miro_delete_item first for 'delete item', got %+v", names(got))
+	}
+}
+
+func TestScoreTools_DescriptionShortened(t *testing.T) {
+	longTools := []ToolSpec{
+		{
+			Name:     "miro_create_long",
+			Method:   "CreateLong",
+			Title:    "Long",
+			Category: "create",
+			Description: "Short summary line.\n\n" +
+				"USE WHEN: very long second paragraph that should not propagate through " +
+				strings.Repeat("X", 500),
+		},
+	}
+	got := scoreTools(ToolSearchArgs{Query: "create"}, longTools)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 match, got %d", len(got))
+	}
+	if strings.Contains(got[0].Description, "USE WHEN") {
+		t.Errorf("description shortener should have stopped at first newline: %q", got[0].Description)
+	}
+	if len([]rune(got[0].Description)) > 200 {
+		t.Errorf("description longer than cap: %d runes", len([]rune(got[0].Description)))
+	}
+}
+
+func TestSearchTools_ReturnsStructuredResult(t *testing.T) {
+	h := &HandlerRegistry{}
+	res, err := h.SearchTools(context.Background(), ToolSearchArgs{Query: "sticky"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Total != len(res.Tools) {
+		t.Errorf("Total %d != len(Tools) %d", res.Total, len(res.Tools))
+	}
+	if res.Message == "" {
+		t.Errorf("expected non-empty message")
+	}
+}
+
+func TestTokenize_FiltersShortTokens(t *testing.T) {
+	got := tokenize("a b ab create_sticky")
+	want := []string{"ab", "create", "sticky"}
+	if len(got) != len(want) {
+		t.Fatalf("tokenize = %v, want %v", got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Errorf("token[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func names(matches []ToolSearchMatch) []string {
+	out := make([]string, len(matches))
+	for i, m := range matches {
+		out[i] = m.Name
+	}
+	return out
+}


### PR DESCRIPTION
## Summary

Two complementary mechanisms for token-efficient tool discovery, both opt-in (default behavior unchanged):

1. **`miro_tool_search(query?, category?, limit?)`** — server-side discovery meta-tool. Weighted keyword scoring across name (3x), title (2x), category (2.5x), description (1x). Multi-term OR. Self-recursion guarded. Descriptions truncated to first non-empty line + 200 chars. Up to 50 matches.

2. **`MIRO_TOOLS_PROFILE=full|essentials`** — operator selects the registered tool surface. `full` (default) keeps all 92 tools; `essentials` registers only the discovery meta-tool plus 14 high-frequency tools (boards, list/find, sticky/text/frame/connector creation, list/get/update/delete items). **~85% surface reduction.** Agents reach the rest via `miro_tool_search` on demand.

## Motivation

Per Sam Morrow's 4-axis MCP framework (escalation bead `claude-code-config-xxc`), miro had 91 tools — the largest schema preload in the portfolio (~18k tokens at session start). This addresses axis 1 (Token Efficiency) without breaking existing users.

This is the path of least friction:
- Anthropic's `tool_search` is now the default in Claude Code (per Sam Morrow, 13-04-2026). For Claude Code users, the savings are already accruing — this commit makes descriptions and categories more searchable.
- For non-Claude-Code clients (Cursor, Cline, n8n), `MIRO_TOOLS_PROFILE=essentials` is graceful degradation: agents discover the long tail via the meta-tool.
- Selective tool collapse (productplan-style `manage_*` merging) is deferred — it's a one-way door that breaks user workflows. Tool count is `+1`, not `−66`.

## Backward compatibility

- Default profile is `full`; existing users get all 92 tools as before
- New tool count: 91 → 92 (the `miro_tool_search` meta-tool itself)
- Unknown `MIRO_TOOLS_PROFILE` values fall back to `full` with a logged warning so a typo doesn't silently strip tools
- README, CONFIG.md, and the SEP-2127 server card description updated to reflect new count

## Smoke results on real `AllTools`

| Query | Top result | Score |
|---|---|---|
| `sticky` | `miro_create_sticky` | 6 |
| `share board` | `miro_share_board` | 12 |
| `diagram` | `miro_generate_diagram` | 6 |
| `get items` | `miro_get_frame_items` | 12 |
| empty + `category=create` | alphabetical creators | 0 |

## Test plan

- [x] `go test -race ./tools/...` — all pass including new `search_test.go` and `profile_test.go`
- [x] `go test -race ./...` — full suite green
- [x] `golangci-lint run ./...` — clean
- [x] Updated `TestToolCount` and `TestToolCategories` for new tool count + `discovery` category
- [ ] Manual: invoke `miro_tool_search` from Claude Code; confirm reasonable ranking
- [ ] Manual: start server with `MIRO_TOOLS_PROFILE=essentials`; confirm only 15 tools listed

## Follow-up (not in this PR)

- After release, monitor `miro_tool_search` usage in audit logs; if call rate is high, consider adding query-suggestion or "did you mean" hints
- Selective tool-name collapse (e.g. `miro_create_sticky/card/text` → `miro_create_item(type=...)`) deferred until usage data shows safe redundancy

🤖 Generated with [Claude Code](https://claude.com/claude-code)