### PR TITLE
security: close HG-1, HG-2, path-injection findings (Carlini portfolio sweep)

### DIFF
--- a/miro/boards.go
+++ b/miro/boards.go
@@ -91,8 +91,8 @@ func (c *Client) ListBoards(ctx context.Context, args ListBoardsArgs) (ListBoard
 
 // GetBoard retrieves a specific board by ID.
 func (c *Client) GetBoard(ctx context.Context, args GetBoardArgs) (GetBoardResult, error) {
-	if args.BoardID == "" {
-		return GetBoardResult{}, fmt.Errorf("board_id is required")
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return GetBoardResult{}, err
 	}
 
 	// Check cache
@@ -158,8 +158,8 @@ func (c *Client) CreateBoard(ctx context.Context, args CreateBoardArgs) (CreateB
 // CopyBoard copies an existing board.
 // Uses PUT /boards?copy_from={board_id} as per Miro API docs.
 func (c *Client) CopyBoard(ctx context.Context, args CopyBoardArgs) (CopyBoardResult, error) {
-	if args.BoardID == "" {
-		return CopyBoardResult{}, fmt.Errorf("board_id is required")
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return CopyBoardResult{}, err
 	}
 
 	reqBody := make(map[string]interface{})
@@ -196,8 +196,8 @@ func (c *Client) CopyBoard(ctx context.Context, args CopyBoardArgs) (CopyBoardRe
 
 // DeleteBoard deletes a board.
 func (c *Client) DeleteBoard(ctx context.Context, args DeleteBoardArgs) (DeleteBoardResult, error) {
-	if args.BoardID == "" {
-		return DeleteBoardResult{}, fmt.Errorf("board_id is required")
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return DeleteBoardResult{}, err
 	}
 
 	// Dry-run mode: return preview without deleting
@@ -293,8 +293,8 @@ func (c *Client) FindBoardByNameTool(ctx context.Context, args FindBoardByNameAr
 
 // UpdateBoard updates a board's name and/or description.
 func (c *Client) UpdateBoard(ctx context.Context, args UpdateBoardArgs) (UpdateBoardResult, error) {
-	if args.BoardID == "" {
-		return UpdateBoardResult{}, fmt.Errorf("board_id is required")
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return UpdateBoardResult{}, err
 	}
 	if args.Name == "" && args.Description == "" {
 		return UpdateBoardResult{}, fmt.Errorf("at least one of name or description is required")
@@ -332,8 +332,8 @@ func (c *Client) UpdateBoard(ctx context.Context, args UpdateBoardArgs) (UpdateB
 
 // GetBoardSummary retrieves a board with item counts and statistics.
 func (c *Client) GetBoardSummary(ctx context.Context, args GetBoardSummaryArgs) (GetBoardSummaryResult, error) {
-	if args.BoardID == "" {
-		return GetBoardSummaryResult{}, fmt.Errorf("board_id is required")
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return GetBoardSummaryResult{}, err
 	}
 
 	// Get board details
@@ -376,8 +376,8 @@ func (c *Client) GetBoardSummary(ctx context.Context, args GetBoardSummaryArgs) 
 // This is designed to provide rich, structured data that an AI agent can
 // analyze to generate documentation, summaries, or insights.
 func (c *Client) GetBoardContent(ctx context.Context, args GetBoardContentArgs) (GetBoardContentResult, error) {
-	if args.BoardID == "" {
-		return GetBoardContentResult{}, fmt.Errorf("board_id is required")
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return GetBoardContentResult{}, err
 	}
 
 	// Set defaults

--- a/miro/client.go
+++ b/miro/client.go
@@ -262,6 +262,23 @@ func ValidateItemID(id string) error {
 	return nil
 }
 
+// ValidateOrgID ensures an organization ID is safe and well-formed.
+// Used by export tools that hit /orgs/{org_id}/... endpoints. Without this
+// validation, a prompt-injected agent could pivot the URL to other Miro
+// API paths via path-segment injection.
+func ValidateOrgID(id string) error {
+	if id == "" {
+		return fmt.Errorf("org_id is required")
+	}
+	if len(id) > maxIDLen {
+		return fmt.Errorf("org_id too long (max %d characters)", maxIDLen)
+	}
+	if !validIDPattern.MatchString(id) {
+		return fmt.Errorf("org_id contains invalid characters")
+	}
+	return nil
+}
+
 // ValidateContent ensures content is within allowed limits.
 func ValidateContent(content string) error {
 	if len(content) > maxContentLen {

--- a/miro/create.go
+++ b/miro/create.go
@@ -16,8 +16,8 @@ import (
 
 // CreateSticky creates a sticky note on a board.
 func (c *Client) CreateSticky(ctx context.Context, args CreateStickyArgs) (CreateStickyResult, error) {
-	if args.BoardID == "" {
-		return CreateStickyResult{}, fmt.Errorf("board_id is required")
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return CreateStickyResult{}, err
 	}
 	if args.Content == "" {
 		return CreateStickyResult{}, fmt.Errorf("content is required")
@@ -81,8 +81,8 @@ func (c *Client) CreateSticky(ctx context.Context, args CreateStickyArgs) (Creat
 
 // CreateShape creates a shape on a board.
 func (c *Client) CreateShape(ctx context.Context, args CreateShapeArgs) (CreateShapeResult, error) {
-	if args.BoardID == "" {
-		return CreateShapeResult{}, fmt.Errorf("board_id is required")
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return CreateShapeResult{}, err
 	}
 	if args.Shape == "" {
 		return CreateShapeResult{}, fmt.Errorf("shape type is required")
@@ -179,8 +179,8 @@ type CreateShapeExperimentalArgs struct {
 // CreateShapeExperimental creates a shape using the v2-experimental API.
 // Used for flowchart stencil shapes that require the experimental endpoint.
 func (c *Client) CreateShapeExperimental(ctx context.Context, args CreateShapeExperimentalArgs) (CreateShapeResult, error) {
-	if args.BoardID == "" {
-		return CreateShapeResult{}, fmt.Errorf("board_id is required")
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return CreateShapeResult{}, err
 	}
 	if args.Shape == "" {
 		return CreateShapeResult{}, fmt.Errorf("shape type is required")
@@ -262,8 +262,8 @@ func (c *Client) CreateShapeExperimental(ctx context.Context, args CreateShapeEx
 
 // CreateText creates a text item on a board.
 func (c *Client) CreateText(ctx context.Context, args CreateTextArgs) (CreateTextResult, error) {
-	if args.BoardID == "" {
-		return CreateTextResult{}, fmt.Errorf("board_id is required")
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return CreateTextResult{}, err
 	}
 	if args.Content == "" {
 		return CreateTextResult{}, fmt.Errorf("content is required")
@@ -330,8 +330,8 @@ func (c *Client) CreateText(ctx context.Context, args CreateTextArgs) (CreateTex
 
 // ListConnectors returns a list of connectors on a board.
 func (c *Client) ListConnectors(ctx context.Context, args ListConnectorsArgs) (ListConnectorsResult, error) {
-	if args.BoardID == "" {
-		return ListConnectorsResult{}, fmt.Errorf("board_id is required")
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return ListConnectorsResult{}, err
 	}
 
 	limit := args.Limit
@@ -395,8 +395,8 @@ func extractCaption(captions []Caption) string {
 
 // GetConnector retrieves a specific connector by ID.
 func (c *Client) GetConnector(ctx context.Context, args GetConnectorArgs) (GetConnectorResult, error) {
-	if args.BoardID == "" {
-		return GetConnectorResult{}, fmt.Errorf("board_id is required")
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return GetConnectorResult{}, err
 	}
 	if args.ConnectorID == "" {
 		return GetConnectorResult{}, fmt.Errorf("connector_id is required")
@@ -446,8 +446,8 @@ func (c *Client) GetConnector(ctx context.Context, args GetConnectorArgs) (GetCo
 
 // CreateConnector creates a connector between two items.
 func (c *Client) CreateConnector(ctx context.Context, args CreateConnectorArgs) (CreateConnectorResult, error) {
-	if args.BoardID == "" {
-		return CreateConnectorResult{}, fmt.Errorf("board_id is required")
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return CreateConnectorResult{}, err
 	}
 	if args.StartItemID == "" || args.EndItemID == "" {
 		return CreateConnectorResult{}, fmt.Errorf("start_item_id and end_item_id are required")
@@ -510,8 +510,8 @@ func (c *Client) CreateConnector(ctx context.Context, args CreateConnectorArgs) 
 
 // UpdateConnector updates an existing connector.
 func (c *Client) UpdateConnector(ctx context.Context, args UpdateConnectorArgs) (UpdateConnectorResult, error) {
-	if args.BoardID == "" {
-		return UpdateConnectorResult{}, fmt.Errorf("board_id is required")
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return UpdateConnectorResult{}, err
 	}
 	if args.ConnectorID == "" {
 		return UpdateConnectorResult{}, fmt.Errorf("connector_id is required")
@@ -574,8 +574,8 @@ func (c *Client) UpdateConnector(ctx context.Context, args UpdateConnectorArgs) 
 
 // DeleteConnector removes a connector from a board.
 func (c *Client) DeleteConnector(ctx context.Context, args DeleteConnectorArgs) (DeleteConnectorResult, error) {
-	if args.BoardID == "" {
-		return DeleteConnectorResult{}, fmt.Errorf("board_id is required")
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return DeleteConnectorResult{}, err
 	}
 	if args.ConnectorID == "" {
 		return DeleteConnectorResult{}, fmt.Errorf("connector_id is required")
@@ -613,8 +613,8 @@ func (c *Client) DeleteConnector(ctx context.Context, args DeleteConnectorArgs) 
 
 // CreateFrame creates a frame container on a board.
 func (c *Client) CreateFrame(ctx context.Context, args CreateFrameArgs) (CreateFrameResult, error) {
-	if args.BoardID == "" {
-		return CreateFrameResult{}, fmt.Errorf("board_id is required")
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return CreateFrameResult{}, err
 	}
 
 	// Default dimensions
@@ -680,8 +680,8 @@ func (c *Client) CreateFrame(ctx context.Context, args CreateFrameArgs) (CreateF
 
 // CreateCard creates a card on a board.
 func (c *Client) CreateCard(ctx context.Context, args CreateCardArgs) (CreateCardResult, error) {
-	if args.BoardID == "" {
-		return CreateCardResult{}, fmt.Errorf("board_id is required")
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return CreateCardResult{}, err
 	}
 	if args.Title == "" {
 		return CreateCardResult{}, fmt.Errorf("title is required")
@@ -742,8 +742,8 @@ func (c *Client) CreateCard(ctx context.Context, args CreateCardArgs) (CreateCar
 
 // CreateImage creates an image on a board from a URL.
 func (c *Client) CreateImage(ctx context.Context, args CreateImageArgs) (CreateImageResult, error) {
-	if args.BoardID == "" {
-		return CreateImageResult{}, fmt.Errorf("board_id is required")
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return CreateImageResult{}, err
 	}
 	if args.URL == "" {
 		return CreateImageResult{}, fmt.Errorf("url is required")
@@ -806,8 +806,8 @@ func (c *Client) CreateImage(ctx context.Context, args CreateImageArgs) (CreateI
 
 // CreateDocument creates a document on a board from a URL.
 func (c *Client) CreateDocument(ctx context.Context, args CreateDocumentArgs) (CreateDocumentResult, error) {
-	if args.BoardID == "" {
-		return CreateDocumentResult{}, fmt.Errorf("board_id is required")
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return CreateDocumentResult{}, err
 	}
 	if args.URL == "" {
 		return CreateDocumentResult{}, fmt.Errorf("url is required")
@@ -869,8 +869,8 @@ func (c *Client) CreateDocument(ctx context.Context, args CreateDocumentArgs) (C
 
 // CreateEmbed creates an embedded content item on a board.
 func (c *Client) CreateEmbed(ctx context.Context, args CreateEmbedArgs) (CreateEmbedResult, error) {
-	if args.BoardID == "" {
-		return CreateEmbedResult{}, fmt.Errorf("board_id is required")
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return CreateEmbedResult{}, err
 	}
 	if args.URL == "" {
 		return CreateEmbedResult{}, fmt.Errorf("url is required")
@@ -940,8 +940,8 @@ func (c *Client) CreateEmbed(ctx context.Context, args CreateEmbedArgs) (CreateE
 
 // CreateStickyGrid creates multiple sticky notes in a grid layout.
 func (c *Client) CreateStickyGrid(ctx context.Context, args CreateStickyGridArgs) (CreateStickyGridResult, error) {
-	if args.BoardID == "" {
-		return CreateStickyGridResult{}, fmt.Errorf("board_id is required")
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return CreateStickyGridResult{}, err
 	}
 	if len(args.Contents) == 0 {
 		return CreateStickyGridResult{}, fmt.Errorf("at least one content item is required")

--- a/miro/diagrams.go
+++ b/miro/diagrams.go
@@ -14,8 +14,8 @@ import (
 
 // GenerateDiagram parses diagram code and creates shapes/connectors on a board.
 func (c *Client) GenerateDiagram(ctx context.Context, args GenerateDiagramArgs) (GenerateDiagramResult, error) {
-	if args.BoardID == "" {
-		return GenerateDiagramResult{}, fmt.Errorf("board_id is required")
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return GenerateDiagramResult{}, err
 	}
 	if args.Diagram == "" {
 		return GenerateDiagramResult{}, fmt.Errorf("diagram code is required")

--- a/miro/docs.go
+++ b/miro/docs.go
@@ -10,8 +10,8 @@ import (
 
 // CreateDocFormat creates a doc format item from Markdown content on a board.
 func (c *Client) CreateDocFormat(ctx context.Context, args CreateDocFormatArgs) (CreateDocFormatResult, error) {
-	if args.BoardID == "" {
-		return CreateDocFormatResult{}, fmt.Errorf("board_id is required")
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return CreateDocFormatResult{}, err
 	}
 	if args.Content == "" {
 		return CreateDocFormatResult{}, fmt.Errorf("content is required")
@@ -62,11 +62,11 @@ func (c *Client) CreateDocFormat(ctx context.Context, args CreateDocFormatArgs) 
 
 // GetDocFormat gets the details of a doc format item.
 func (c *Client) GetDocFormat(ctx context.Context, args GetDocFormatArgs) (GetDocFormatResult, error) {
-	if args.BoardID == "" {
-		return GetDocFormatResult{}, fmt.Errorf("board_id is required")
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return GetDocFormatResult{}, err
 	}
-	if args.ItemID == "" {
-		return GetDocFormatResult{}, fmt.Errorf("item_id is required")
+	if err := ValidateItemID(args.ItemID); err != nil {
+		return GetDocFormatResult{}, err
 	}
 
 	path := fmt.Sprintf("/boards/%s/docs/%s", args.BoardID, args.ItemID)
@@ -112,11 +112,11 @@ func (c *Client) GetDocFormat(ctx context.Context, args GetDocFormatArgs) (GetDo
 
 // DeleteDocFormat deletes a doc format item from a board.
 func (c *Client) DeleteDocFormat(ctx context.Context, args DeleteDocFormatArgs) (DeleteDocFormatResult, error) {
-	if args.BoardID == "" {
-		return DeleteDocFormatResult{}, fmt.Errorf("board_id is required")
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return DeleteDocFormatResult{}, err
 	}
-	if args.ItemID == "" {
-		return DeleteDocFormatResult{}, fmt.Errorf("item_id is required")
+	if err := ValidateItemID(args.ItemID); err != nil {
+		return DeleteDocFormatResult{}, err
 	}
 
 	if args.DryRun {
@@ -148,11 +148,11 @@ func (c *Client) DeleteDocFormat(ctx context.Context, args DeleteDocFormatArgs) 
 // reads the current doc, applies changes, deletes the original, and
 // recreates it at the same position with the new content.
 func (c *Client) UpdateDocFormat(ctx context.Context, args UpdateDocFormatArgs) (UpdateDocFormatResult, error) {
-	if args.BoardID == "" {
-		return UpdateDocFormatResult{}, fmt.Errorf("board_id is required")
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return UpdateDocFormatResult{}, err
 	}
-	if args.ItemID == "" {
-		return UpdateDocFormatResult{}, fmt.Errorf("item_id is required")
+	if err := ValidateItemID(args.ItemID); err != nil {
+		return UpdateDocFormatResult{}, err
 	}
 
 	// Step 1: Read current doc

--- a/miro/errors.go
+++ b/miro/errors.go
@@ -95,13 +95,19 @@ func (e *APIError) Suggestion() string {
 // =============================================================================
 
 // ParseAPIError parses an HTTP response into a structured APIError.
+//
+// The raw response body is NEVER assigned to apiErr.Message. Non-JSON or
+// malformed-JSON responses fall back to http.StatusText so the MCP caller
+// gets a stable, sanitized status string. Operators who need the raw body
+// for incident debugging can log it at the request site (Client.request)
+// before calling ParseAPIError. See HG-2 in rules/code-review-prompts.md.
 func ParseAPIError(resp *http.Response, body []byte) *APIError {
 	apiErr := &APIError{
 		StatusCode: resp.StatusCode,
-		Message:    string(body),
 	}
 
-	// Try to parse as JSON error
+	// Try to parse as JSON error envelope. Only fields that JSON-decoded
+	// reach apiErr; raw body is dropped on every code path.
 	var jsonErr struct {
 		Code    string `json:"code"`
 		Message string `json:"message"`
@@ -109,13 +115,15 @@ func ParseAPIError(resp *http.Response, body []byte) *APIError {
 		Status  int    `json:"status"`
 		Context string `json:"context"`
 	}
-	if err := json.Unmarshal(body, &jsonErr); err == nil {
-		if jsonErr.Message != "" {
-			apiErr.Message = jsonErr.Message
-		}
+	if err := json.Unmarshal(body, &jsonErr); err == nil && jsonErr.Message != "" {
 		apiErr.Code = jsonErr.Code
+		apiErr.Message = jsonErr.Message
 		apiErr.Type = jsonErr.Type
 		apiErr.Context = jsonErr.Context
+	} else {
+		// Non-JSON, malformed JSON, or JSON without a usable message field.
+		// Don't leak the raw body — return a stable status string instead.
+		apiErr.Message = http.StatusText(resp.StatusCode)
 	}
 
 	// Parse Retry-After header for rate limits

--- a/miro/errors_test.go
+++ b/miro/errors_test.go
@@ -178,6 +178,8 @@ func TestParseAPIError_RateLimitWithRetryAfter(t *testing.T) {
 }
 
 func TestParseAPIError_PlainText(t *testing.T) {
+	// Non-JSON body must NOT flow through to apiErr.Message — the falls-back
+	// to http.StatusText. Stable, no leak. (HG-2 regression test.)
 	resp := &http.Response{
 		StatusCode: 500,
 		Header:     http.Header{},
@@ -189,8 +191,71 @@ func TestParseAPIError_PlainText(t *testing.T) {
 	if err.StatusCode != 500 {
 		t.Errorf("StatusCode = %d, want 500", err.StatusCode)
 	}
-	if err.Message != "Internal Server Error" {
-		t.Errorf("Message = %q, want 'Internal Server Error'", err.Message)
+	want := http.StatusText(500)
+	if err.Message != want {
+		t.Errorf("Message = %q, want %q (http.StatusText fallback)", err.Message, want)
+	}
+}
+
+// TestParseAPIError_HTMLBodyDoesNotLeak is the HG-2 regression test. It asserts
+// that an HTML response body (typical of CDN/edge errors during Miro outages,
+// or corp MITM proxy responses) is NOT propagated into the caller-facing error
+// string. Before the fix, ParseAPIError would assign Message = string(body)
+// unconditionally and only override it when JSON decoding succeeded with a
+// non-empty message field — so HTML bodies leaked verbatim into MCP errors.
+func TestParseAPIError_HTMLBodyDoesNotLeak(t *testing.T) {
+	resp := &http.Response{
+		StatusCode: 502,
+		Header:     http.Header{},
+	}
+	body := []byte(`<html><head><title>502 Bad Gateway</title></head>` +
+		`<body><h1>nginx/1.21.6 internal-host.miro.local</h1>` +
+		`<p>request_id: abc-secret-123</p></body></html>`)
+
+	err := ParseAPIError(resp, body)
+
+	if err.StatusCode != 502 {
+		t.Errorf("StatusCode = %d, want 502", err.StatusCode)
+	}
+	leakSentinels := []string{
+		"<html>",
+		"nginx",
+		"internal-host.miro.local",
+		"abc-secret-123",
+	}
+	msg := err.Error()
+	for _, leak := range leakSentinels {
+		if strings.Contains(msg, leak) {
+			t.Errorf("HG-2 regression: error message leaked %q into caller-facing string: %q", leak, msg)
+		}
+	}
+	// And verify the fallback message is the stable status text.
+	wantMsg := http.StatusText(502)
+	if err.Message != wantMsg {
+		t.Errorf("Message = %q, want %q", err.Message, wantMsg)
+	}
+}
+
+// TestParseAPIError_EmptyJSONMessageDoesNotLeak verifies that JSON bodies
+// without a usable `message` field also fall back to StatusText rather than
+// echoing the original body bytes.
+func TestParseAPIError_EmptyJSONMessageDoesNotLeak(t *testing.T) {
+	resp := &http.Response{
+		StatusCode: 400,
+		Header:     http.Header{},
+	}
+	// JSON parses fine but message is empty — pre-fix this would have left
+	// Message = string(body) verbatim because the override was conditional on
+	// jsonErr.Message != "".
+	body := []byte(`{"code":"bad_request","message":""}`)
+
+	err := ParseAPIError(resp, body)
+
+	if strings.Contains(err.Error(), `"code"`) || strings.Contains(err.Error(), `"message"`) {
+		t.Errorf("HG-2 regression: error message echoed raw JSON: %q", err.Error())
+	}
+	if err.Message != http.StatusText(400) {
+		t.Errorf("Message = %q, want %q", err.Message, http.StatusText(400))
 	}
 }
 

--- a/miro/errors_test.go
+++ b/miro/errors_test.go
@@ -230,7 +230,7 @@ func TestParseAPIError_HTMLBodyDoesNotLeak(t *testing.T) {
 		}
 	}
 	// And verify the fallback message is the stable status text.
-	wantMsg := http.StatusText(502)
+	wantMsg := http.StatusText(http.StatusBadGateway)
 	if err.Message != wantMsg {
 		t.Errorf("Message = %q, want %q", err.Message, wantMsg)
 	}

--- a/miro/export.go
+++ b/miro/export.go
@@ -16,8 +16,8 @@ import (
 // GetBoardPicture retrieves the preview image URL for a board.
 // This works for all Miro plans and provides a thumbnail of the board.
 func (c *Client) GetBoardPicture(ctx context.Context, args GetBoardPictureArgs) (GetBoardPictureResult, error) {
-	if args.BoardID == "" {
-		return GetBoardPictureResult{}, fmt.Errorf("board_id is required")
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return GetBoardPictureResult{}, err
 	}
 
 	// Get board details (which includes the picture)
@@ -54,14 +54,19 @@ func (c *Client) GetBoardPicture(ctx context.Context, args GetBoardPictureArgs) 
 // This is an Enterprise-only feature requiring the boards:export scope.
 // Up to 50 boards can be exported in a single job.
 func (c *Client) CreateExportJob(ctx context.Context, args CreateExportJobArgs) (CreateExportJobResult, error) {
-	if args.OrgID == "" {
-		return CreateExportJobResult{}, fmt.Errorf("org_id is required (Enterprise feature)")
+	if err := ValidateOrgID(args.OrgID); err != nil {
+		return CreateExportJobResult{}, fmt.Errorf("%w (Enterprise feature)", err)
 	}
 	if len(args.BoardIDs) == 0 {
 		return CreateExportJobResult{}, fmt.Errorf("board_ids is required (at least one board)")
 	}
 	if len(args.BoardIDs) > 50 {
 		return CreateExportJobResult{}, fmt.Errorf("maximum 50 boards per export job")
+	}
+	for i, boardID := range args.BoardIDs {
+		if err := ValidateBoardID(boardID); err != nil {
+			return CreateExportJobResult{}, fmt.Errorf("board_ids[%d]: %w", i, err)
+		}
 	}
 
 	// Generate request ID if not provided
@@ -111,8 +116,8 @@ func (c *Client) CreateExportJob(ctx context.Context, args CreateExportJobArgs) 
 // GetExportJobStatus retrieves the status of an export job.
 // This is an Enterprise-only feature.
 func (c *Client) GetExportJobStatus(ctx context.Context, args GetExportJobStatusArgs) (GetExportJobStatusResult, error) {
-	if args.OrgID == "" {
-		return GetExportJobStatusResult{}, fmt.Errorf("org_id is required")
+	if err := ValidateOrgID(args.OrgID); err != nil {
+		return GetExportJobStatusResult{}, err
 	}
 	if args.JobID == "" {
 		return GetExportJobStatusResult{}, fmt.Errorf("job_id is required")
@@ -156,8 +161,8 @@ func (c *Client) GetExportJobStatus(ctx context.Context, args GetExportJobStatus
 // This is an Enterprise-only feature.
 // Download links are valid for 15 minutes; call again to regenerate if expired.
 func (c *Client) GetExportJobResults(ctx context.Context, args GetExportJobResultsArgs) (GetExportJobResultsResult, error) {
-	if args.OrgID == "" {
-		return GetExportJobResultsResult{}, fmt.Errorf("org_id is required")
+	if err := ValidateOrgID(args.OrgID); err != nil {
+		return GetExportJobResultsResult{}, err
 	}
 	if args.JobID == "" {
 		return GetExportJobResultsResult{}, fmt.Errorf("job_id is required")

--- a/miro/frames.go
+++ b/miro/frames.go
@@ -15,8 +15,8 @@ import (
 
 // GetFrame retrieves a specific frame by ID.
 func (c *Client) GetFrame(ctx context.Context, args GetFrameArgs) (GetFrameResult, error) {
-	if args.BoardID == "" {
-		return GetFrameResult{}, fmt.Errorf("board_id is required")
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return GetFrameResult{}, err
 	}
 	if args.FrameID == "" {
 		return GetFrameResult{}, fmt.Errorf("frame_id is required")
@@ -80,8 +80,8 @@ func (c *Client) GetFrame(ctx context.Context, args GetFrameArgs) (GetFrameResul
 
 // UpdateFrame updates an existing frame.
 func (c *Client) UpdateFrame(ctx context.Context, args UpdateFrameArgs) (UpdateFrameResult, error) {
-	if args.BoardID == "" {
-		return UpdateFrameResult{}, fmt.Errorf("board_id is required")
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return UpdateFrameResult{}, err
 	}
 	if args.FrameID == "" {
 		return UpdateFrameResult{}, fmt.Errorf("frame_id is required")
@@ -154,8 +154,8 @@ func (c *Client) UpdateFrame(ctx context.Context, args UpdateFrameArgs) (UpdateF
 
 // DeleteFrame removes a frame from a board.
 func (c *Client) DeleteFrame(ctx context.Context, args DeleteFrameArgs) (DeleteFrameResult, error) {
-	if args.BoardID == "" {
-		return DeleteFrameResult{}, fmt.Errorf("board_id is required")
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return DeleteFrameResult{}, err
 	}
 	if args.FrameID == "" {
 		return DeleteFrameResult{}, fmt.Errorf("frame_id is required")
@@ -193,8 +193,8 @@ func (c *Client) DeleteFrame(ctx context.Context, args DeleteFrameArgs) (DeleteF
 // GetFrameItems retrieves all items within a specific frame.
 // When detail_level=full, additional fields (style, geometry, timestamps, user info) are included.
 func (c *Client) GetFrameItems(ctx context.Context, args GetFrameItemsArgs) (GetFrameItemsResult, error) {
-	if args.BoardID == "" {
-		return GetFrameItemsResult{}, fmt.Errorf("board_id is required")
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return GetFrameItemsResult{}, err
 	}
 	if args.FrameID == "" {
 		return GetFrameItemsResult{}, fmt.Errorf("frame_id is required")

--- a/miro/items.go
+++ b/miro/items.go
@@ -19,8 +19,8 @@ import (
 // ListItems retrieves items from a board.
 // When detail_level=full, additional fields (style, geometry, timestamps, user info) are included.
 func (c *Client) ListItems(ctx context.Context, args ListItemsArgs) (ListItemsResult, error) {
-	if args.BoardID == "" {
-		return ListItemsResult{}, fmt.Errorf("board_id is required")
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return ListItemsResult{}, err
 	}
 
 	params := url.Values{}
@@ -174,11 +174,11 @@ func parseItemSummary(raw json.RawMessage, fullDetails bool) ItemSummary {
 
 // GetItem retrieves detailed information about a specific item.
 func (c *Client) GetItem(ctx context.Context, args GetItemArgs) (GetItemResult, error) {
-	if args.BoardID == "" {
-		return GetItemResult{}, fmt.Errorf("board_id is required")
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return GetItemResult{}, err
 	}
-	if args.ItemID == "" {
-		return GetItemResult{}, fmt.Errorf("item_id is required")
+	if err := ValidateItemID(args.ItemID); err != nil {
+		return GetItemResult{}, err
 	}
 
 	// Check cache first
@@ -262,11 +262,11 @@ func (c *Client) GetItem(ctx context.Context, args GetItemArgs) (GetItemResult, 
 
 // UpdateItem updates an existing item.
 func (c *Client) UpdateItem(ctx context.Context, args UpdateItemArgs) (UpdateItemResult, error) {
-	if args.BoardID == "" {
-		return UpdateItemResult{}, fmt.Errorf("board_id is required")
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return UpdateItemResult{}, err
 	}
-	if args.ItemID == "" {
-		return UpdateItemResult{}, fmt.Errorf("item_id is required")
+	if err := ValidateItemID(args.ItemID); err != nil {
+		return UpdateItemResult{}, err
 	}
 
 	// Build update body - only include provided fields
@@ -349,11 +349,11 @@ func (c *Client) UpdateItem(ctx context.Context, args UpdateItemArgs) (UpdateIte
 
 // DeleteItem deletes an item from a board.
 func (c *Client) DeleteItem(ctx context.Context, args DeleteItemArgs) (DeleteItemResult, error) {
-	if args.BoardID == "" {
-		return DeleteItemResult{}, fmt.Errorf("board_id is required")
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return DeleteItemResult{}, err
 	}
-	if args.ItemID == "" {
-		return DeleteItemResult{}, fmt.Errorf("item_id is required")
+	if err := ValidateItemID(args.ItemID); err != nil {
+		return DeleteItemResult{}, err
 	}
 
 	// Dry-run mode: return preview without deleting
@@ -465,8 +465,8 @@ func categorizeBulkError(index int, itemID string, err error) BulkItemError {
 // Items are created in parallel using goroutines, with concurrency
 // controlled by the client's semaphore (MaxConcurrentRequests).
 func (c *Client) BulkCreate(ctx context.Context, args BulkCreateArgs) (BulkCreateResult, error) {
-	if args.BoardID == "" {
-		return BulkCreateResult{}, fmt.Errorf("board_id is required")
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return BulkCreateResult{}, err
 	}
 	if len(args.Items) == 0 {
 		return BulkCreateResult{}, fmt.Errorf("at least one item is required")
@@ -592,8 +592,8 @@ func (c *Client) BulkCreate(ctx context.Context, args BulkCreateArgs) (BulkCreat
 // Items are updated in parallel using goroutines, with concurrency
 // controlled by the client's semaphore (MaxConcurrentRequests).
 func (c *Client) BulkUpdate(ctx context.Context, args BulkUpdateArgs) (BulkUpdateResult, error) {
-	if args.BoardID == "" {
-		return BulkUpdateResult{}, fmt.Errorf("board_id is required")
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return BulkUpdateResult{}, err
 	}
 	if len(args.Items) == 0 {
 		return BulkUpdateResult{}, fmt.Errorf("at least one item is required")
@@ -701,8 +701,8 @@ func (c *Client) BulkUpdate(ctx context.Context, args BulkUpdateArgs) (BulkUpdat
 // Items are deleted in parallel using goroutines, with concurrency
 // controlled by the client's semaphore (MaxConcurrentRequests).
 func (c *Client) BulkDelete(ctx context.Context, args BulkDeleteArgs) (BulkDeleteResult, error) {
-	if args.BoardID == "" {
-		return BulkDeleteResult{}, fmt.Errorf("board_id is required")
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return BulkDeleteResult{}, err
 	}
 	if len(args.ItemIDs) == 0 {
 		return BulkDeleteResult{}, fmt.Errorf("at least one item_id is required")
@@ -783,8 +783,8 @@ func (c *Client) BulkDelete(ctx context.Context, args BulkDeleteArgs) (BulkDelet
 
 // ListAllItems retrieves all items from a board with automatic pagination.
 func (c *Client) ListAllItems(ctx context.Context, args ListAllItemsArgs) (ListAllItemsResult, error) {
-	if args.BoardID == "" {
-		return ListAllItemsResult{}, fmt.Errorf("board_id is required")
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return ListAllItemsResult{}, err
 	}
 
 	maxItems := args.MaxItems
@@ -845,8 +845,8 @@ func (c *Client) ListAllItems(ctx context.Context, args ListAllItemsArgs) (ListA
 
 // SearchBoard searches for items containing specific text.
 func (c *Client) SearchBoard(ctx context.Context, args SearchBoardArgs) (SearchBoardResult, error) {
-	if args.BoardID == "" {
-		return SearchBoardResult{}, fmt.Errorf("board_id is required")
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return SearchBoardResult{}, err
 	}
 	if args.Query == "" {
 		return SearchBoardResult{}, fmt.Errorf("query is required")
@@ -1376,11 +1376,11 @@ func createSnippet(content, query string, contextLen int) string {
 
 // GetImage retrieves details of a specific image item.
 func (c *Client) GetImage(ctx context.Context, args GetImageArgs) (GetImageResult, error) {
-	if args.BoardID == "" {
-		return GetImageResult{}, fmt.Errorf("board_id is required")
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return GetImageResult{}, err
 	}
-	if args.ItemID == "" {
-		return GetImageResult{}, fmt.Errorf("item_id is required")
+	if err := ValidateItemID(args.ItemID); err != nil {
+		return GetImageResult{}, err
 	}
 
 	cacheKey := CacheKeyItem(args.BoardID, args.ItemID)
@@ -1438,11 +1438,11 @@ func (c *Client) GetImage(ctx context.Context, args GetImageArgs) (GetImageResul
 
 // GetDocument retrieves details of a specific document item.
 func (c *Client) GetDocument(ctx context.Context, args GetDocumentArgs) (GetDocumentResult, error) {
-	if args.BoardID == "" {
-		return GetDocumentResult{}, fmt.Errorf("board_id is required")
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return GetDocumentResult{}, err
 	}
-	if args.ItemID == "" {
-		return GetDocumentResult{}, fmt.Errorf("item_id is required")
+	if err := ValidateItemID(args.ItemID); err != nil {
+		return GetDocumentResult{}, err
 	}
 
 	cacheKey := CacheKeyItem(args.BoardID, args.ItemID)

--- a/miro/mindmaps.go
+++ b/miro/mindmaps.go
@@ -112,8 +112,8 @@ func truncateMindmap(s string, max int) string {
 
 // GetMindmapNode retrieves a specific mindmap node.
 func (c *Client) GetMindmapNode(ctx context.Context, args GetMindmapNodeArgs) (GetMindmapNodeResult, error) {
-	if args.BoardID == "" {
-		return GetMindmapNodeResult{}, fmt.Errorf("board_id is required")
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return GetMindmapNodeResult{}, err
 	}
 	if args.NodeID == "" {
 		return GetMindmapNodeResult{}, fmt.Errorf("node_id is required")
@@ -182,8 +182,8 @@ func (c *Client) GetMindmapNode(ctx context.Context, args GetMindmapNodeArgs) (G
 
 // ListMindmapNodes retrieves all mindmap nodes on a board.
 func (c *Client) ListMindmapNodes(ctx context.Context, args ListMindmapNodesArgs) (ListMindmapNodesResult, error) {
-	if args.BoardID == "" {
-		return ListMindmapNodesResult{}, fmt.Errorf("board_id is required")
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return ListMindmapNodesResult{}, err
 	}
 
 	limit := args.Limit
@@ -254,8 +254,8 @@ func (c *Client) ListMindmapNodes(ctx context.Context, args ListMindmapNodesArgs
 
 // DeleteMindmapNode removes a mindmap node.
 func (c *Client) DeleteMindmapNode(ctx context.Context, args DeleteMindmapNodeArgs) (DeleteMindmapNodeResult, error) {
-	if args.BoardID == "" {
-		return DeleteMindmapNodeResult{}, fmt.Errorf("board_id is required")
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return DeleteMindmapNodeResult{}, err
 	}
 	if args.NodeID == "" {
 		return DeleteMindmapNodeResult{}, fmt.Errorf("node_id is required")

--- a/miro/tables.go
+++ b/miro/tables.go
@@ -10,8 +10,8 @@ import (
 
 // ListTables lists data table format items on a board.
 func (c *Client) ListTables(ctx context.Context, args ListTablesArgs) (ListTablesResult, error) {
-	if args.BoardID == "" {
-		return ListTablesResult{}, fmt.Errorf("board_id is required")
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return ListTablesResult{}, err
 	}
 
 	limit := args.Limit
@@ -89,11 +89,11 @@ func (c *Client) ListTables(ctx context.Context, args ListTablesArgs) (ListTable
 
 // GetTable gets metadata for a specific data table format item.
 func (c *Client) GetTable(ctx context.Context, args GetTableArgs) (GetTableResult, error) {
-	if args.BoardID == "" {
-		return GetTableResult{}, fmt.Errorf("board_id is required")
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return GetTableResult{}, err
 	}
-	if args.ItemID == "" {
-		return GetTableResult{}, fmt.Errorf("item_id is required")
+	if err := ValidateItemID(args.ItemID); err != nil {
+		return GetTableResult{}, err
 	}
 
 	path := fmt.Sprintf("/boards/%s/data_table_formats/%s", args.BoardID, args.ItemID)

--- a/miro/tags.go
+++ b/miro/tags.go
@@ -16,8 +16,8 @@ import (
 
 // CreateTag creates a tag on a board.
 func (c *Client) CreateTag(ctx context.Context, args CreateTagArgs) (CreateTagResult, error) {
-	if args.BoardID == "" {
-		return CreateTagResult{}, fmt.Errorf("board_id is required")
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return CreateTagResult{}, err
 	}
 	if args.Title == "" {
 		return CreateTagResult{}, fmt.Errorf("title is required")
@@ -55,8 +55,8 @@ func (c *Client) CreateTag(ctx context.Context, args CreateTagArgs) (CreateTagRe
 
 // ListTags retrieves all tags from a board.
 func (c *Client) ListTags(ctx context.Context, args ListTagsArgs) (ListTagsResult, error) {
-	if args.BoardID == "" {
-		return ListTagsResult{}, fmt.Errorf("board_id is required")
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return ListTagsResult{}, err
 	}
 
 	params := url.Values{}
@@ -94,11 +94,11 @@ func (c *Client) ListTags(ctx context.Context, args ListTagsArgs) (ListTagsResul
 
 // AttachTag attaches a tag to an item (sticky note).
 func (c *Client) AttachTag(ctx context.Context, args AttachTagArgs) (AttachTagResult, error) {
-	if args.BoardID == "" {
-		return AttachTagResult{}, fmt.Errorf("board_id is required")
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return AttachTagResult{}, err
 	}
-	if args.ItemID == "" {
-		return AttachTagResult{}, fmt.Errorf("item_id is required")
+	if err := ValidateItemID(args.ItemID); err != nil {
+		return AttachTagResult{}, err
 	}
 	if args.TagID == "" {
 		return AttachTagResult{}, fmt.Errorf("tag_id is required")
@@ -126,11 +126,11 @@ func (c *Client) AttachTag(ctx context.Context, args AttachTagArgs) (AttachTagRe
 
 // DetachTag removes a tag from an item.
 func (c *Client) DetachTag(ctx context.Context, args DetachTagArgs) (DetachTagResult, error) {
-	if args.BoardID == "" {
-		return DetachTagResult{}, fmt.Errorf("board_id is required")
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return DetachTagResult{}, err
 	}
-	if args.ItemID == "" {
-		return DetachTagResult{}, fmt.Errorf("item_id is required")
+	if err := ValidateItemID(args.ItemID); err != nil {
+		return DetachTagResult{}, err
 	}
 	if args.TagID == "" {
 		return DetachTagResult{}, fmt.Errorf("tag_id is required")
@@ -158,11 +158,11 @@ func (c *Client) DetachTag(ctx context.Context, args DetachTagArgs) (DetachTagRe
 
 // GetItemTags retrieves tags attached to an item.
 func (c *Client) GetItemTags(ctx context.Context, args GetItemTagsArgs) (GetItemTagsResult, error) {
-	if args.BoardID == "" {
-		return GetItemTagsResult{}, fmt.Errorf("board_id is required")
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return GetItemTagsResult{}, err
 	}
-	if args.ItemID == "" {
-		return GetItemTagsResult{}, fmt.Errorf("item_id is required")
+	if err := ValidateItemID(args.ItemID); err != nil {
+		return GetItemTagsResult{}, err
 	}
 
 	path := fmt.Sprintf("/boards/%s/items/%s/tags", args.BoardID, args.ItemID)
@@ -240,8 +240,8 @@ func (c *Client) GetTag(ctx context.Context, args GetTagArgs) (GetTagResult, err
 // UpdateTag updates an existing tag on a board.
 // When only color is provided, preserves the existing title (and vice versa).
 func (c *Client) UpdateTag(ctx context.Context, args UpdateTagArgs) (UpdateTagResult, error) {
-	if args.BoardID == "" {
-		return UpdateTagResult{}, fmt.Errorf("board_id is required")
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return UpdateTagResult{}, err
 	}
 	if args.TagID == "" {
 		return UpdateTagResult{}, fmt.Errorf("tag_id is required")
@@ -296,8 +296,8 @@ func (c *Client) UpdateTag(ctx context.Context, args UpdateTagArgs) (UpdateTagRe
 
 // DeleteTag removes a tag from a board.
 func (c *Client) DeleteTag(ctx context.Context, args DeleteTagArgs) (DeleteTagResult, error) {
-	if args.BoardID == "" {
-		return DeleteTagResult{}, fmt.Errorf("board_id is required")
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return DeleteTagResult{}, err
 	}
 	if args.TagID == "" {
 		return DeleteTagResult{}, fmt.Errorf("tag_id is required")
@@ -332,8 +332,8 @@ func (c *Client) DeleteTag(ctx context.Context, args DeleteTagArgs) (DeleteTagRe
 
 // GetItemsByTag returns items on a board filtered by tag ID.
 func (c *Client) GetItemsByTag(ctx context.Context, args GetItemsByTagArgs) (GetItemsByTagResult, error) {
-	if args.BoardID == "" {
-		return GetItemsByTagResult{}, fmt.Errorf("board_id is required")
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return GetItemsByTagResult{}, err
 	}
 	if args.TagID == "" {
 		return GetItemsByTagResult{}, fmt.Errorf("tag_id is required")

--- a/miro/upload.go
+++ b/miro/upload.go
@@ -72,8 +72,8 @@ func ValidateUploadPath(filePath string) (string, error) {
 
 // UploadImage uploads a local image file to a Miro board.
 func (c *Client) UploadImage(ctx context.Context, args UploadImageArgs) (UploadImageResult, error) {
-	if args.BoardID == "" {
-		return UploadImageResult{}, fmt.Errorf("board_id is required")
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return UploadImageResult{}, err
 	}
 	if args.FilePath == "" {
 		return UploadImageResult{}, fmt.Errorf("file_path is required")
@@ -149,8 +149,8 @@ func (c *Client) UploadImage(ctx context.Context, args UploadImageArgs) (UploadI
 
 // UploadDocument uploads a local document file to a Miro board.
 func (c *Client) UploadDocument(ctx context.Context, args UploadDocumentArgs) (UploadDocumentResult, error) {
-	if args.BoardID == "" {
-		return UploadDocumentResult{}, fmt.Errorf("board_id is required")
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return UploadDocumentResult{}, err
 	}
 	if args.FilePath == "" {
 		return UploadDocumentResult{}, fmt.Errorf("file_path is required")
@@ -232,11 +232,11 @@ func (c *Client) UploadDocument(ctx context.Context, args UploadDocumentArgs) (U
 
 // UpdateImageFromFile replaces the file on an existing image item via PATCH multipart.
 func (c *Client) UpdateImageFromFile(ctx context.Context, args UpdateImageFromFileArgs) (UpdateImageFromFileResult, error) {
-	if args.BoardID == "" {
-		return UpdateImageFromFileResult{}, fmt.Errorf("board_id is required")
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return UpdateImageFromFileResult{}, err
 	}
-	if args.ItemID == "" {
-		return UpdateImageFromFileResult{}, fmt.Errorf("item_id is required")
+	if err := ValidateItemID(args.ItemID); err != nil {
+		return UpdateImageFromFileResult{}, err
 	}
 	if args.FilePath == "" {
 		return UpdateImageFromFileResult{}, fmt.Errorf("file_path is required")
@@ -307,11 +307,11 @@ func (c *Client) UpdateImageFromFile(ctx context.Context, args UpdateImageFromFi
 
 // UpdateDocumentFromFile replaces the file on an existing document item via PATCH multipart.
 func (c *Client) UpdateDocumentFromFile(ctx context.Context, args UpdateDocumentFromFileArgs) (UpdateDocumentFromFileResult, error) {
-	if args.BoardID == "" {
-		return UpdateDocumentFromFileResult{}, fmt.Errorf("board_id is required")
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return UpdateDocumentFromFileResult{}, err
 	}
-	if args.ItemID == "" {
-		return UpdateDocumentFromFileResult{}, fmt.Errorf("item_id is required")
+	if err := ValidateItemID(args.ItemID); err != nil {
+		return UpdateDocumentFromFileResult{}, err
 	}
 	if args.FilePath == "" {
 		return UpdateDocumentFromFileResult{}, fmt.Errorf("file_path is required")

--- a/miro/validate_paths_test.go
+++ b/miro/validate_paths_test.go
@@ -1,0 +1,89 @@
+package miro
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestValidatePaths_RejectInjectionPayloads is a regression suite for the
+// path-injection finding (Carlini scan, miro Finding 2). Each payload class
+// the URL parser silently rewrites or that pivots the destination must be
+// rejected at the validator layer BEFORE the request reaches Miro.
+func TestValidatePaths_RejectInjectionPayloads(t *testing.T) {
+	cases := []struct {
+		name string
+		id   string
+	}{
+		{"query injection", "valid?team_id=victim"},
+		{"path traversal", "../../etc/passwd"},
+		{"slash extension", "valid/items/extra"},
+		{"hash anchor", "valid#anchor"},
+		{"semicolon param", "valid;param"},
+		{"ampersand", "valid&query=injected"},
+		{"percent-encoded slash", "valid%2F../something"},
+		{"newline injection", "valid\nX-Inject: 1"},
+		{"null byte", "valid\x00.attacker.com"},
+		{"empty", ""},
+		{"only whitespace", "   "},
+		{"oversize", strings.Repeat("a", 101)},
+	}
+
+	for _, c := range cases {
+		t.Run("BoardID/"+c.name, func(t *testing.T) {
+			if err := ValidateBoardID(c.id); err == nil {
+				t.Errorf("ValidateBoardID(%q) returned nil; expected rejection", c.id)
+			}
+		})
+		t.Run("ItemID/"+c.name, func(t *testing.T) {
+			if err := ValidateItemID(c.id); err == nil {
+				t.Errorf("ValidateItemID(%q) returned nil; expected rejection", c.id)
+			}
+		})
+		t.Run("OrgID/"+c.name, func(t *testing.T) {
+			if err := ValidateOrgID(c.id); err == nil {
+				t.Errorf("ValidateOrgID(%q) returned nil; expected rejection", c.id)
+			}
+		})
+	}
+}
+
+// TestValidatePaths_AcceptRealMiroIDs verifies the validator does not regress
+// legitimate Miro IDs. Real IDs observed in production use letters, digits,
+// underscore, hyphen, and `=` (Base64 padding).
+func TestValidatePaths_AcceptRealMiroIDs(t *testing.T) {
+	realIDs := []string{
+		"uXjVPzd1234=",
+		"uXjVO_abc-DEF",
+		"o9J_kxyz123=",
+		"3458764500000",
+		"abc",
+	}
+
+	for _, id := range realIDs {
+		if err := ValidateBoardID(id); err != nil {
+			t.Errorf("ValidateBoardID(%q) returned %v; expected nil for real Miro ID", id, err)
+		}
+		if err := ValidateItemID(id); err != nil {
+			t.Errorf("ValidateItemID(%q) returned %v; expected nil for real Miro ID", id, err)
+		}
+		if err := ValidateOrgID(id); err != nil {
+			t.Errorf("ValidateOrgID(%q) returned %v; expected nil for real Miro ID", id, err)
+		}
+	}
+}
+
+// TestClient_RejectsInjectedBoardID exercises the integrated path through one
+// representative client method and asserts that the request never goes out.
+// Uses a real Client with no transport — the validator must reject before the
+// HTTP layer is touched.
+func TestClient_RejectsInjectedBoardID(t *testing.T) {
+	c := &Client{}
+	_, err := c.ListItems(context.Background(), ListItemsArgs{BoardID: "valid?team_id=victim"})
+	if err == nil {
+		t.Fatal("ListItems accepted query-injected board_id; expected validator rejection")
+	}
+	if !strings.Contains(err.Error(), "board_id") {
+		t.Errorf("error did not mention board_id: %v", err)
+	}
+}

--- a/resources/resources.go
+++ b/resources/resources.go
@@ -72,6 +72,13 @@ func (r *Registry) handleBoardResource(ctx context.Context, req *mcp.ReadResourc
 		boardID = boardID[:idx]
 	}
 
+	// Validate before passing to the client. Without this gate a prompt-
+	// injected URI like miro://board/abc?team_id=victim flows raw into the
+	// Miro API URL and pivots the request away from the intended endpoint.
+	if err := miroclient.ValidateBoardID(boardID); err != nil {
+		return nil, mcp.ResourceNotFoundError(req.Params.URI)
+	}
+
 	// Get board summary (includes metadata and item counts)
 	summary, err := r.client.GetBoardSummary(ctx, miroclient.GetBoardSummaryArgs{
 		BoardID: boardID,
@@ -106,6 +113,10 @@ func (r *Registry) handleBoardItemsResource(ctx context.Context, req *mcp.ReadRe
 
 	// Remove /items suffix
 	boardID = strings.TrimSuffix(boardID, "/items")
+
+	if err := miroclient.ValidateBoardID(boardID); err != nil {
+		return nil, mcp.ResourceNotFoundError(req.Params.URI)
+	}
 
 	// Get all items on the board
 	items, err := r.client.ListAllItems(ctx, miroclient.ListAllItemsArgs{
@@ -142,6 +153,10 @@ func (r *Registry) handleBoardFramesResource(ctx context.Context, req *mcp.ReadR
 
 	// Remove /frames suffix
 	boardID = strings.TrimSuffix(boardID, "/frames")
+
+	if err := miroclient.ValidateBoardID(boardID); err != nil {
+		return nil, mcp.ResourceNotFoundError(req.Params.URI)
+	}
 
 	// Get all items and filter for frames
 	items, err := r.client.ListItems(ctx, miroclient.ListItemsArgs{

--- a/tools/handlers.go
+++ b/tools/handlers.go
@@ -2,6 +2,8 @@ package tools
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -426,6 +428,12 @@ func (h *HandlerRegistry) buildTool(spec ToolSpec) *mcp.Tool {
 }
 
 // registerTool is a generic helper that registers a tool with the MCP server.
+//
+// The dispatcher closure uses NAMED return values so the deferred recoverPanic
+// can reassign `err` on panic. Without named returns, Go cannot mutate the
+// return values from a deferred function and a panic-then-recover would surface
+// as `(nil, zero, nil)` to the MCP caller — looking like a successful empty
+// response. See HG-1 in rules/code-review-prompts.md.
 func registerTool[Args, Result any](
 	h *HandlerRegistry,
 	server *mcp.Server,
@@ -433,25 +441,25 @@ func registerTool[Args, Result any](
 	spec ToolSpec,
 	method func(context.Context, Args) (Result, error),
 ) {
-	mcp.AddTool(server, tool, func(ctx context.Context, req *mcp.CallToolRequest, args Args) (*mcp.CallToolResult, Result, error) {
-		defer h.recoverPanic(spec.Name)
+	mcp.AddTool(server, tool, func(ctx context.Context, req *mcp.CallToolRequest, args Args) (res *mcp.CallToolResult, out Result, err error) {
+		defer h.recoverPanic(spec.Name, &err)
 
 		// Apply desire path normalization to raw arguments
 		args = normalizeArgs(h, spec.Name, req, args)
 
 		start := time.Now()
-		result, err := method(ctx, args)
+		result, methodErr := method(ctx, args)
 		duration := time.Since(start)
 
 		// Create and log audit event
-		event := h.createAuditEvent(spec, args, result, err, duration)
+		event := h.createAuditEvent(spec, args, result, methodErr, duration)
 		if auditErr := h.auditLogger.Log(ctx, event); auditErr != nil {
 			h.logger.Warn("Failed to log audit event", "error", auditErr)
 		}
 
-		if err != nil {
+		if methodErr != nil {
 			var zero Result
-			return nil, zero, fmt.Errorf("%s failed: %w", spec.Name, err)
+			return nil, zero, fmt.Errorf("%s failed: %w", spec.Name, methodErr)
 		}
 
 		h.logExecution(spec, args, result)
@@ -606,14 +614,37 @@ func argsToMap(v any) map[string]interface{} {
 	return result
 }
 
-// recoverPanic recovers from panics in tool handlers.
-func (h *HandlerRegistry) recoverPanic(toolName string) {
-	if rec := recover(); rec != nil {
-		h.logger.Error("Panic recovered",
-			"tool", toolName,
-			"panic", rec,
-			"stack", string(debug.Stack()))
+// recoverPanic recovers from panics in tool handlers and converts them into a
+// structured error with a correlation ID. The panic value and stack are logged
+// server-side; only the correlation ID reaches the MCP caller.
+//
+// MUST be called as `defer h.recoverPanic(spec.Name, &err)` from a function
+// with NAMED return values. Without named returns the deferred reassignment
+// is a no-op and panics surface as silent fake-success responses.
+func (h *HandlerRegistry) recoverPanic(toolName string, errPtr *error) {
+	rec := recover()
+	if rec == nil {
+		return
 	}
+	corrID := newCorrelationID()
+	h.logger.Error("Panic recovered",
+		"tool", toolName,
+		"correlation_id", corrID,
+		"panic", rec,
+		"stack", string(debug.Stack()))
+	if errPtr != nil {
+		*errPtr = fmt.Errorf("%s: internal error (correlation_id=%s)", toolName, corrID)
+	}
+}
+
+// newCorrelationID returns a short hex string for log correlation. Falls back
+// to a timestamp-based ID if crypto/rand is unavailable (vanishingly rare).
+func newCorrelationID() string {
+	b := make([]byte, 8)
+	if _, err := rand.Read(b); err != nil {
+		return fmt.Sprintf("ts-%d", time.Now().UnixNano())
+	}
+	return hex.EncodeToString(b)
 }
 
 // logExecution logs tool execution details.

--- a/tools/handlers_test.go
+++ b/tools/handlers_test.go
@@ -993,33 +993,7 @@ func TestArgsToMap(t *testing.T) {
 	}
 }
 
-// =============================================================================
-// recoverPanic Tests
-// =============================================================================
-
-func TestRecoverPanic(t *testing.T) {
-	mock := &MockClient{}
-	registry := newTestRegistry(mock)
-
-	// Should recover from panic without crashing
-	func() {
-		defer registry.recoverPanic("test_tool")
-		panic("test panic")
-	}()
-
-	// If we get here, panic was recovered successfully
-}
-
-func TestRecoverPanicNoPanic(t *testing.T) {
-	mock := &MockClient{}
-	registry := newTestRegistry(mock)
-
-	// Should handle case where no panic occurs
-	func() {
-		defer registry.recoverPanic("test_tool")
-		// No panic, just normal execution
-	}()
-}
+// recoverPanic tests live in recover_test.go (HG-1 regression suite).
 
 // =============================================================================
 // logExecution Tests

--- a/tools/recover_test.go
+++ b/tools/recover_test.go
@@ -1,0 +1,79 @@
+package tools
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestRecoverPanic_AssignsErrorWithCorrelationID is a regression test for HG-1.
+// The dispatcher's deferred recover MUST reassign the named `err` return so a
+// panicking handler surfaces as a structured error to the MCP caller, not as
+// `(nil, zero, nil)` which the SDK would treat as a successful empty response.
+func TestRecoverPanic_AssignsErrorWithCorrelationID(t *testing.T) {
+	registry := newTestRegistry(&MockClient{})
+
+	err := func() (err error) {
+		defer registry.recoverPanic("test_tool", &err)
+		panic("secret panic value")
+	}()
+
+	if err == nil {
+		t.Fatal("expected non-nil error after panic, got nil — HG-1 silent fake-success regression")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "test_tool: internal error") {
+		t.Errorf("error message missing tool name and 'internal error': %q", msg)
+	}
+	if !strings.Contains(msg, "correlation_id=") {
+		t.Errorf("error message missing correlation_id: %q", msg)
+	}
+	if strings.Contains(msg, "secret panic value") {
+		t.Errorf("error message leaked panic value: %q", msg)
+	}
+}
+
+// TestRecoverPanic_NoPanicNoError verifies the success path is unchanged.
+func TestRecoverPanic_NoPanicNoError(t *testing.T) {
+	registry := newTestRegistry(&MockClient{})
+
+	err := func() (err error) {
+		defer registry.recoverPanic("test_tool", &err)
+		return nil
+	}()
+
+	if err != nil {
+		t.Errorf("expected no error when no panic, got: %v", err)
+	}
+}
+
+// TestRecoverPanic_PreservesExistingError verifies that recoverPanic on a
+// non-panicking path doesn't clobber an existing returned error.
+func TestRecoverPanic_PreservesExistingError(t *testing.T) {
+	registry := newTestRegistry(&MockClient{})
+
+	sentinel := errStub("real error")
+	err := func() (err error) {
+		defer registry.recoverPanic("test_tool", &err)
+		return sentinel
+	}()
+
+	if err != sentinel {
+		t.Errorf("recoverPanic clobbered existing error: got %v, want %v", err, sentinel)
+	}
+}
+
+// TestNewCorrelationID_DistinctAndShaped verifies the correlation ID generator.
+func TestNewCorrelationID_DistinctAndShaped(t *testing.T) {
+	a := newCorrelationID()
+	b := newCorrelationID()
+	if a == b {
+		t.Errorf("expected distinct correlation IDs, got same: %q", a)
+	}
+	if len(a) != 16 {
+		t.Errorf("expected 16-char hex ID, got len %d: %q", len(a), a)
+	}
+}
+
+type errStub string
+
+func (e errStub) Error() string { return string(e) }


### PR DESCRIPTION
## Summary

Three security fixes from a Carlini-style autonomous-vulnerability scaffold sweep across the MCP portfolio (2026-05-02). All are direct violations of hard gates already graduated in `rules/review-patterns.md` (2026-04-25); miro is one of the source servers for HG-2 and was previously cited as a reference implementation.

| Finding | Severity | Hard Gate | Files |
|---|---|---|---|
| Dispatcher panic returns silent fake-success | Critical | HG-1 | tools/handlers.go (+ recover_test.go) |
| `ParseAPIError` leaks raw response body in error message | Medium | HG-2 | miro/errors.go |
| `BoardID`/`ItemID`/`OrgID` skip validation at 30+ path-construction sites | High | (graduation-blocking pattern) | 13 files in miro/, resources/resources.go |

### Finding 1 — HG-1 silent fake-success on panic

The `registerTool` closure used unnamed return values, so the deferred `recoverPanic` could only log — not reassign the named `err`. A panic anywhere in the closure (`normalizeArgs`, `method`, audit-event creation, `logExecution`) returned `(nil, zero, nil)`. Verified against go-sdk v1.5.0:
- `toolForErr` adapter (server.go:285-374) treats `res == nil` + `err == nil` as success and synthesizes an empty `&CallToolResult{}` from the zero-valued typed Result.
- `callTool` (server.go:743-760) has no panic recovery of its own.

Result: a panicking handler surfaced to the MCP caller as `{"content": [], "structuredContent": {}}` — a successful empty response with no error signal and no audit-log entry.

Fix: named return values, `defer h.recoverPanic(spec.Name, &err)`, recover reassigns `err` to a generic message with a correlation ID. Panic value never reaches the caller.

### Finding 2 — Path-injection via missing ID validation

`ValidateBoardID` and `ValidateItemID` exist (regex `^[a-zA-Z0-9_=\-]+$`, max 100 chars) but were only called from ~5 of ~35 path-construction sites. Verified exploit primitive against Go's URL parser:

```
args.BoardID = "valid?team_id=victim"
-> "https://api.miro.com/v2/boards/valid?team_id=victim/sticky_notes"
```

The `?` silently splits into a query parameter; the rest of the intended path (`/sticky_notes`) is swallowed into the value. Reachable from prompt injection. Audit-log spoofing and cache-prefix collision are additional impacts.

Fix: replace 60+ empty-string checks with `Validate{Board,Item,Org}ID`. Add `ValidateOrgID`. Validate inside `CreateExportJob`'s BoardIDs slice. Validate at all three resource handlers.

### Finding 3 — HG-2 raw body in `ParseAPIError`

`apiErr.Message = string(body)` was assigned unconditionally before JSON decode, then overridden only when JSON parsed AND `message` was non-empty. Non-JSON, malformed-JSON, and empty-message-JSON bodies all surfaced verbatim.

Fix: drop unconditional pre-assignment; fall back to `http.StatusText(StatusCode)` when JSON envelope unusable.

## UX impact

- **Finding 1**: strictly improves the broken path. Today's silent fake-success becomes a clear error with correlation ID. Success path unchanged. No regression.
- **Finding 2**: real Miro IDs (`uXjVPzd1234=`, `o9J_kxyz123=`, etc.) all match the validator regex — verified by `TestValidatePaths_AcceptRealMiroIDs`. No legitimate workflow regresses. Invalid IDs now get a clear error before hitting Miro.
- **Finding 3**: invisible in steady-state (Miro normally returns JSON errors). During Miro outages or CDN errors, agent now sees `Miro API error [503]: Service Unavailable` instead of a 5KB nginx error page.

## Test plan

- [x] `go build ./...` clean
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test -race -failfast ./...` — 11 packages, all green
- [x] New regression suites:
  - HG-1: `TestRecoverPanic_AssignsErrorWithCorrelationID`, `TestRecoverPanic_NoPanicNoError`, `TestRecoverPanic_PreservesExistingError`, `TestNewCorrelationID_DistinctAndShaped`
  - HG-2: `TestParseAPIError_HTMLBodyDoesNotLeak`, `TestParseAPIError_EmptyJSONMessageDoesNotLeak`, plus updated `TestParseAPIError_PlainText`
  - Path injection: `TestValidatePaths_RejectInjectionPayloads` (12 payload classes × 3 validators = 36 sub-tests), `TestValidatePaths_AcceptRealMiroIDs`, `TestClient_RejectsInjectedBoardID`

## Suggested release

**v1.20.0** (minor bump). The HG-1 fix changes panic semantics from "silent empty success" to "structured error with correlation ID" — agents may observe this as a behavior change even though the previous behavior was a bug. Other fixes are pure security tightening with no agent-visible regression.

## Out of scope (follow-up)

- `url.PathEscape` belt-and-braces on path components — validator regex already restricts to URL-safe chars; add when/if regex loosens.
- `c.cache.InvalidatePrefix(...)` delimiter fix — current pattern allows prefix collision across boards. Separate concern.
- Image upload size cap on `UploadImage`/`UpdateImageFromFile` (was rated Medium-DoS in the scan, downgraded to Low after path-validator review).
- `update_board_member` allowlist wrapper (Low; description acknowledges role-promotion blast radius but no allowlist gate).

## Refs

- `/tmp/vuln-scan-miro/` — full per-agent scan reports
- `/tmp/vuln-scan-PORTFOLIO.md` — cross-portfolio findings
- `rules/review-patterns.md` — graduated hard gates (HG-1, HG-2, HG-3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)