### PR TITLE
refactor(codescene): lift code health scores across miro-mcp-server

### DIFF
--- a/miro/audit/factory.go
+++ b/miro/audit/factory.go
@@ -26,46 +26,65 @@ func NewLogger(config Config) (Logger, error) {
 	return NewFileLogger(config)
 }
 
+// envBoolean parses a boolean-style env value ("true" / "1"). Empty input
+// leaves dst untouched.
+func envBoolean(name string, dst *bool) {
+	val := os.Getenv(name)
+	if val == "" {
+		return
+	}
+	*dst = strings.ToLower(val) == "true" || val == "1"
+}
+
+// envString assigns a non-empty env value to dst.
+func envString(name string, dst *string) {
+	if val := os.Getenv(name); val != "" {
+		*dst = val
+	}
+}
+
+// envRetentionDays parses MIRO_AUDIT_RETENTION as a day-suffixed duration.
+func envRetentionDays(name string, dst *int) {
+	val := os.Getenv(name)
+	if val == "" {
+		return
+	}
+	if days := parseDuration(val); days > 0 {
+		*dst = days
+	}
+}
+
+// envMaxSize parses MIRO_AUDIT_MAX_SIZE as a K/M/G-suffixed byte size.
+func envMaxSize(name string, dst *int64) {
+	val := os.Getenv(name)
+	if val == "" {
+		return
+	}
+	if size := parseSize(val); size > 0 {
+		*dst = size
+	}
+}
+
+// envNonNegativeInt parses a non-negative integer env value.
+func envNonNegativeInt(name string, dst *int) {
+	val := os.Getenv(name)
+	if val == "" {
+		return
+	}
+	if size, err := strconv.Atoi(val); err == nil && size >= 0 {
+		*dst = size
+	}
+}
+
 // LoadConfigFromEnv loads audit configuration from environment variables.
 func LoadConfigFromEnv() Config {
 	config := DefaultConfig()
-
-	// MIRO_AUDIT_ENABLED
-	if val := os.Getenv("MIRO_AUDIT_ENABLED"); val != "" {
-		config.Enabled = strings.ToLower(val) == "true" || val == "1"
-	}
-
-	// MIRO_AUDIT_PATH
-	if val := os.Getenv("MIRO_AUDIT_PATH"); val != "" {
-		config.Path = val
-	}
-
-	// MIRO_AUDIT_RETENTION
-	if val := os.Getenv("MIRO_AUDIT_RETENTION"); val != "" {
-		if days := parseDuration(val); days > 0 {
-			config.RetentionDays = days
-		}
-	}
-
-	// MIRO_AUDIT_MAX_SIZE
-	if val := os.Getenv("MIRO_AUDIT_MAX_SIZE"); val != "" {
-		if size := parseSize(val); size > 0 {
-			config.MaxSizeBytes = size
-		}
-	}
-
-	// MIRO_AUDIT_BUFFER_SIZE
-	if val := os.Getenv("MIRO_AUDIT_BUFFER_SIZE"); val != "" {
-		if size, err := strconv.Atoi(val); err == nil && size >= 0 {
-			config.BufferSize = size
-		}
-	}
-
-	// MIRO_AUDIT_SANITIZE
-	if val := os.Getenv("MIRO_AUDIT_SANITIZE"); val != "" {
-		config.SanitizeInput = strings.ToLower(val) == "true" || val == "1"
-	}
-
+	envBoolean("MIRO_AUDIT_ENABLED", &config.Enabled)
+	envString("MIRO_AUDIT_PATH", &config.Path)
+	envRetentionDays("MIRO_AUDIT_RETENTION", &config.RetentionDays)
+	envMaxSize("MIRO_AUDIT_MAX_SIZE", &config.MaxSizeBytes)
+	envNonNegativeInt("MIRO_AUDIT_BUFFER_SIZE", &config.BufferSize)
+	envBoolean("MIRO_AUDIT_SANITIZE", &config.SanitizeInput)
 	return config
 }
 
@@ -231,28 +250,40 @@ var (
 // Action Detection
 // =============================================================================
 
+// actionPrefixes maps each Action to the method-name prefixes that signal it.
+// Order matters only between rows; within a row, any prefix triggers the row's
+// Action.
+var actionPrefixes = []struct {
+	action   Action
+	prefixes []string
+}{
+	{ActionCreate, []string{"create", "bulk"}},
+	{ActionRead, []string{"list", "get", "search", "find"}},
+	{ActionUpdate, []string{"update"}},
+	{ActionDelete, []string{"delete", "ungroup", "detach"}},
+	{ActionExport, []string{"export"}},
+	{ActionAuth, []string{"validate", "share"}},
+}
+
+// hasAnyPrefix reports whether s starts with any of the given prefixes.
+func hasAnyPrefix(s string, prefixes []string) bool {
+	for _, p := range prefixes {
+		if strings.HasPrefix(s, p) {
+			return true
+		}
+	}
+	return false
+}
+
 // DetectAction infers the action type from the method name.
 func DetectAction(method string) Action {
 	method = strings.ToLower(method)
-
-	switch {
-	case strings.HasPrefix(method, "create") || strings.HasPrefix(method, "bulk"):
-		return ActionCreate
-	case strings.HasPrefix(method, "list") || strings.HasPrefix(method, "get") ||
-		strings.HasPrefix(method, "search") || strings.HasPrefix(method, "find"):
-		return ActionRead
-	case strings.HasPrefix(method, "update"):
-		return ActionUpdate
-	case strings.HasPrefix(method, "delete") || strings.HasPrefix(method, "ungroup") ||
-		strings.HasPrefix(method, "detach"):
-		return ActionDelete
-	case strings.HasPrefix(method, "export"):
-		return ActionExport
-	case strings.HasPrefix(method, "validate") || strings.HasPrefix(method, "share"):
-		return ActionAuth
-	default:
-		return ActionRead
+	for _, row := range actionPrefixes {
+		if hasAnyPrefix(method, row.prefixes) {
+			return row.action
+		}
 	}
+	return ActionRead
 }
 
 // FormatDuration returns a human-readable duration.

--- a/miro/audit/file.go
+++ b/miro/audit/file.go
@@ -163,62 +163,83 @@ func (l *FileLogger) cleanupOldFiles() {
 	}
 }
 
-// Query retrieves audit events matching the specified criteria.
-func (l *FileLogger) Query(ctx context.Context, opts QueryOptions) (*QueryResult, error) {
+// flushBufferIfNeeded writes any buffered events to disk before a query.
+func (l *FileLogger) flushBufferIfNeeded() {
 	l.mu.Lock()
-	// Flush buffer first to ensure all events are written
+	defer l.mu.Unlock()
 	if len(l.buffer) > 0 {
 		l.flushLocked()
 	}
-	l.mu.Unlock()
+}
 
-	// Find all log files
+// listJSONLFilesSorted returns the absolute paths of all .jsonl files in the
+// audit log directory, sorted ascending by filename.
+func (l *FileLogger) listJSONLFilesSorted() ([]string, error) {
 	entries, err := os.ReadDir(l.config.Path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read audit log directory: %w", err)
 	}
-
-	// Sort files by name (timestamp order)
-	var files []string
+	files := make([]string, 0, len(entries))
 	for _, entry := range entries {
-		if !entry.IsDir() && filepath.Ext(entry.Name()) == ".jsonl" {
-			files = append(files, filepath.Join(l.config.Path, entry.Name()))
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".jsonl" {
+			continue
 		}
+		files = append(files, filepath.Join(l.config.Path, entry.Name()))
 	}
 	sort.Strings(files)
+	return files, nil
+}
 
-	// Read and filter events from all files
+// collectMatchingEvents reads every file and returns events that satisfy opts,
+// silently skipping files that fail to open.
+func (l *FileLogger) collectMatchingEvents(ctx context.Context, files []string, opts QueryOptions) []Event {
 	var matches []Event
 	for _, filePath := range files {
 		events, err := l.readEventsFromFile(ctx, filePath, opts)
 		if err != nil {
-			continue // Skip files that can't be read
+			continue
 		}
 		matches = append(matches, events...)
 	}
-
-	// Sort by timestamp descending (most recent first)
 	sort.Slice(matches, func(i, j int) bool {
 		return matches[i].Timestamp.After(matches[j].Timestamp)
 	})
+	return matches
+}
 
+// applyOffset returns events[opts.Offset:] without panicking on overshoot.
+func applyOffset(events []Event, offset int) []Event {
+	if offset <= 0 {
+		return events
+	}
+	if offset >= len(events) {
+		return nil
+	}
+	return events[offset:]
+}
+
+// applyLimit trims events to opts.Limit and reports whether anything was cut.
+func applyLimit(events []Event, limit int) ([]Event, bool) {
+	if limit > 0 && len(events) > limit {
+		return events[:limit], true
+	}
+	return events, false
+}
+
+// Query retrieves audit events matching the specified criteria.
+func (l *FileLogger) Query(ctx context.Context, opts QueryOptions) (*QueryResult, error) {
+	l.flushBufferIfNeeded()
+
+	files, err := l.listJSONLFilesSorted()
+	if err != nil {
+		return nil, err
+	}
+
+	matches := l.collectMatchingEvents(ctx, files, opts)
 	total := len(matches)
 
-	// Apply offset
-	if opts.Offset > 0 {
-		if opts.Offset >= len(matches) {
-			matches = nil
-		} else {
-			matches = matches[opts.Offset:]
-		}
-	}
-
-	// Apply limit
-	hasMore := false
-	if opts.Limit > 0 && len(matches) > opts.Limit {
-		matches = matches[:opts.Limit]
-		hasMore = true
-	}
+	matches = applyOffset(matches, opts.Offset)
+	matches, hasMore := applyLimit(matches, opts.Limit)
 
 	return &QueryResult{
 		Events:  matches,

--- a/miro/boards_find.go
+++ b/miro/boards_find.go
@@ -10,6 +10,17 @@ import (
 // Board Search by Name
 // =============================================================================
 
+// findFirstBoardMatch returns the first board whose name (case-insensitive)
+// satisfies match. nameLower must already be lowercased.
+func findFirstBoardMatch(boards []BoardSummary, nameLower string, match func(boardName, target string) bool) *BoardSummary {
+	for i := range boards {
+		if match(strings.ToLower(boards[i].Name), nameLower) {
+			return &boards[i]
+		}
+	}
+	return nil
+}
+
 // FindBoardByName finds a board by exact or partial name match.
 // Returns the best matching board, preferring exact matches.
 func (c *Client) FindBoardByName(ctx context.Context, name string) (*BoardSummary, error) {
@@ -17,43 +28,25 @@ func (c *Client) FindBoardByName(ctx context.Context, name string) (*BoardSummar
 		return nil, fmt.Errorf("board name is required")
 	}
 
-	// Search for boards with the given name
-	result, err := c.ListBoards(ctx, ListBoardsArgs{
-		Query: name,
-		Limit: 20,
-	})
+	result, err := c.ListBoards(ctx, ListBoardsArgs{Query: name, Limit: 20})
 	if err != nil {
 		return nil, fmt.Errorf("failed to search boards: %w", err)
 	}
-
 	if len(result.Boards) == 0 {
 		return nil, fmt.Errorf("no board found matching '%s'", name)
 	}
 
 	nameLower := strings.ToLower(name)
-
-	// First pass: exact match
-	for i := range result.Boards {
-		if strings.ToLower(result.Boards[i].Name) == nameLower {
-			return &result.Boards[i], nil
+	matchers := []func(string, string) bool{
+		func(a, b string) bool { return a == b },
+		strings.HasPrefix,
+		strings.Contains,
+	}
+	for _, m := range matchers {
+		if hit := findFirstBoardMatch(result.Boards, nameLower, m); hit != nil {
+			return hit, nil
 		}
 	}
-
-	// Second pass: starts with match
-	for i := range result.Boards {
-		if strings.HasPrefix(strings.ToLower(result.Boards[i].Name), nameLower) {
-			return &result.Boards[i], nil
-		}
-	}
-
-	// Third pass: contains match
-	for i := range result.Boards {
-		if strings.Contains(strings.ToLower(result.Boards[i].Name), nameLower) {
-			return &result.Boards[i], nil
-		}
-	}
-
-	// Return first result as fallback
 	return &result.Boards[0], nil
 }
 

--- a/miro/boards_summary.go
+++ b/miro/boards_summary.go
@@ -161,28 +161,39 @@ func appendItemByType(by *ItemsByType, item ItemSummary) {
 	}
 }
 
+// childrenOf returns items whose ParentID matches the given frame ID.
+func childrenOf(items []ItemSummary, frameID string) []ItemSummary {
+	var children []ItemSummary
+	for _, child := range items {
+		if child.ParentID == frameID {
+			children = append(children, child)
+		}
+	}
+	return children
+}
+
+// frameContextFromItem builds a FrameContext from a frame item plus its
+// child items.
+func frameContextFromItem(item ItemSummary, items []ItemSummary) FrameContext {
+	return FrameContext{
+		ID:       item.ID,
+		Title:    item.Content,
+		X:        item.X,
+		Y:        item.Y,
+		Width:    item.Width,
+		Height:   item.Height,
+		Children: childrenOf(items, item.ID),
+	}
+}
+
 // buildFrameHierarchy returns a FrameContext per frame item, with each frame's
 // children populated (items whose ParentID points at the frame).
 func buildFrameHierarchy(items []ItemSummary) []FrameContext {
 	var frames []FrameContext
 	for _, item := range items {
-		if item.Type != "frame" {
-			continue
+		if item.Type == "frame" {
+			frames = append(frames, frameContextFromItem(item, items))
 		}
-		frame := FrameContext{
-			ID:     item.ID,
-			Title:  item.Content,
-			X:      item.X,
-			Y:      item.Y,
-			Width:  item.Width,
-			Height: item.Height,
-		}
-		for _, child := range items {
-			if child.ParentID == item.ID {
-				frame.Children = append(frame.Children, child)
-			}
-		}
-		frames = append(frames, frame)
 	}
 	return frames
 }

--- a/miro/card.go
+++ b/miro/card.go
@@ -73,18 +73,9 @@ func (c *Client) CreateCard(ctx context.Context, args CreateCardArgs) (CreateCar
 	}, nil
 }
 
-// UpdateCard updates a card using the dedicated cards endpoint.
-func (c *Client) UpdateCard(ctx context.Context, args UpdateCardArgs) (UpdateCardResult, error) {
-	if err := ValidateBoardID(args.BoardID); err != nil {
-		return UpdateCardResult{}, err
-	}
-	if err := ValidateItemID(args.ItemID); err != nil {
-		return UpdateCardResult{}, fmt.Errorf("invalid item_id: %w", err)
-	}
-
-	reqBody := make(map[string]interface{})
-
-	// Build data section
+// buildCardDataSection returns the optional "data" map for a card update.
+// dueDate may be cleared by passing an empty string.
+func buildCardDataSection(args UpdateCardArgs) map[string]interface{} {
 	data := make(map[string]interface{})
 	if args.Title != nil {
 		data["title"] = *args.Title
@@ -99,38 +90,35 @@ func (c *Client) UpdateCard(ctx context.Context, args UpdateCardArgs) (UpdateCar
 			data["dueDate"] = *args.DueDate
 		}
 	}
-	if len(data) > 0 {
+	return data
+}
+
+// buildUpdateCardBody assembles the PATCH body for a card update.
+func buildUpdateCardBody(args UpdateCardArgs) map[string]interface{} {
+	reqBody := make(map[string]interface{})
+	if data := buildCardDataSection(args); len(data) > 0 {
 		reqBody["data"] = data
 	}
-
-	// Build position section
-	if args.X != nil || args.Y != nil {
-		pos := map[string]interface{}{"origin": "center"}
-		if args.X != nil {
-			pos["x"] = *args.X
-		}
-		if args.Y != nil {
-			pos["y"] = *args.Y
-		}
+	if pos := buildPositionSection(args.X, args.Y); pos != nil {
 		reqBody["position"] = pos
 	}
-
-	// Build geometry section
 	if args.Width != nil {
-		reqBody["geometry"] = map[string]interface{}{
-			"width": *args.Width,
-		}
+		reqBody["geometry"] = map[string]interface{}{"width": *args.Width}
+	}
+	applyParentField(reqBody, args.ParentID)
+	return reqBody
+}
+
+// UpdateCard updates a card using the dedicated cards endpoint.
+func (c *Client) UpdateCard(ctx context.Context, args UpdateCardArgs) (UpdateCardResult, error) {
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return UpdateCardResult{}, err
+	}
+	if err := ValidateItemID(args.ItemID); err != nil {
+		return UpdateCardResult{}, fmt.Errorf("invalid item_id: %w", err)
 	}
 
-	// Build parent section
-	if args.ParentID != nil {
-		if *args.ParentID == "" {
-			reqBody["parent"] = nil
-		} else {
-			reqBody["parent"] = map[string]interface{}{"id": *args.ParentID}
-		}
-	}
-
+	reqBody := buildUpdateCardBody(args)
 	if len(reqBody) == 0 {
 		return UpdateCardResult{
 			ID:      args.ItemID,

--- a/miro/config.go
+++ b/miro/config.go
@@ -104,6 +104,63 @@ func loadTeamIDFromTokensFile() string {
 	return tokens.TeamID
 }
 
+// validateAccessToken returns an error if the access token is missing or
+// malformed.
+func (c *Config) validateAccessToken() error {
+	if c.AccessToken == "" {
+		return &ValidationError{
+			Field:   "AccessToken",
+			Message: "access token is required. Get one at https://miro.com/app/settings/user-profile/apps",
+		}
+	}
+	if !isValidTokenFormat(c.AccessToken) {
+		return &ValidationError{
+			Field:   "AccessToken",
+			Message: "access token format appears invalid. Expected JWT or API token format",
+		}
+	}
+	return nil
+}
+
+// validateAndDefaultTimeout checks the timeout range and applies the default
+// when zero.
+func (c *Config) validateAndDefaultTimeout() error {
+	if c.Timeout < 0 {
+		return &ValidationError{
+			Field:   "Timeout",
+			Message: fmt.Sprintf("timeout cannot be negative: %v", c.Timeout),
+		}
+	}
+	if c.Timeout == 0 {
+		c.Timeout = DefaultTimeout
+		return nil
+	}
+	if c.Timeout < MinTimeout {
+		return &ValidationError{
+			Field:   "Timeout",
+			Message: fmt.Sprintf("timeout %v is below minimum %v", c.Timeout, MinTimeout),
+		}
+	}
+	if c.Timeout > MaxTimeout {
+		return &ValidationError{
+			Field:   "Timeout",
+			Message: fmt.Sprintf("timeout %v exceeds maximum %v", c.Timeout, MaxTimeout),
+		}
+	}
+	return nil
+}
+
+// validateTeamID returns an error if a non-empty TeamID is in the wrong format.
+func (c *Config) validateTeamID() error {
+	if c.TeamID == "" || isValidTeamID(c.TeamID) {
+		return nil
+	}
+	return &ValidationError{
+		Field:   "TeamID",
+		Message: "team ID format appears invalid. Expected numeric string",
+	}
+}
+
 // Validate checks if the Config is valid and applies defaults for optional fields.
 // Returns an error describing the first validation failure found.
 func (c *Config) Validate() error {
@@ -113,58 +170,16 @@ func (c *Config) Validate() error {
 			Message: "configuration is nil",
 		}
 	}
-
-	// Validate access token (required)
-	if c.AccessToken == "" {
-		return &ValidationError{
-			Field:   "AccessToken",
-			Message: "access token is required. Get one at https://miro.com/app/settings/user-profile/apps",
-		}
+	if err := c.validateAccessToken(); err != nil {
+		return err
 	}
-
-	// Basic token format validation (should look like a JWT or API token)
-	if !isValidTokenFormat(c.AccessToken) {
-		return &ValidationError{
-			Field:   "AccessToken",
-			Message: "access token format appears invalid. Expected JWT or API token format",
-		}
+	if err := c.validateAndDefaultTimeout(); err != nil {
+		return err
 	}
-
-	// Validate timeout range
-	if c.Timeout < 0 {
-		return &ValidationError{
-			Field:   "Timeout",
-			Message: fmt.Sprintf("timeout cannot be negative: %v", c.Timeout),
-		}
-	}
-	if c.Timeout == 0 {
-		c.Timeout = DefaultTimeout
-	} else if c.Timeout < MinTimeout {
-		return &ValidationError{
-			Field:   "Timeout",
-			Message: fmt.Sprintf("timeout %v is below minimum %v", c.Timeout, MinTimeout),
-		}
-	} else if c.Timeout > MaxTimeout {
-		return &ValidationError{
-			Field:   "Timeout",
-			Message: fmt.Sprintf("timeout %v exceeds maximum %v", c.Timeout, MaxTimeout),
-		}
-	}
-
-	// Apply default user agent if not set
 	if c.UserAgent == "" {
 		c.UserAgent = "miro-mcp-server/1.0"
 	}
-
-	// TeamID is optional but validate format if provided
-	if c.TeamID != "" && !isValidTeamID(c.TeamID) {
-		return &ValidationError{
-			Field:   "TeamID",
-			Message: "team ID format appears invalid. Expected numeric string",
-		}
-	}
-
-	return nil
+	return c.validateTeamID()
 }
 
 // ValidateConfig checks if the configuration is valid.

--- a/miro/desirepath/logger.go
+++ b/miro/desirepath/logger.go
@@ -125,6 +125,66 @@ type PatternSummary struct {
 	Count     int    `json:"count"`
 }
 
+// patternKey identifies a unique rule/tool/parameter triple.
+type patternKey struct {
+	rule, tool, param string
+}
+
+// ringIndex maps a logical position (0 = oldest) onto the ring-buffer slot.
+func (l *Logger) ringIndex(i int) int {
+	return (l.writePos - l.count + i + l.maxSize) % l.maxSize
+}
+
+// tallyByDimension increments report counters for one event.
+func tallyByDimension(report *Report, event Event) {
+	report.ByRule[event.Rule]++
+	report.ByTool[event.Tool]++
+	report.ByParam[event.Parameter]++
+}
+
+// recordPattern updates the running pattern counter for event.
+func recordPattern(patternCounts map[patternKey]*PatternSummary, event Event) {
+	key := patternKey{event.Rule, event.Tool, event.Parameter}
+	if ps, ok := patternCounts[key]; ok {
+		ps.Count++
+		return
+	}
+	patternCounts[key] = &PatternSummary{
+		Rule:      event.Rule,
+		Tool:      event.Tool,
+		Parameter: event.Parameter,
+		Example:   event.RawValue + " -> " + event.NormalizedTo,
+		Count:     1,
+	}
+}
+
+// topPatterns flattens, sorts (descending count), and truncates to limit.
+func topPatterns(patternCounts map[patternKey]*PatternSummary, limit int) []PatternSummary {
+	patterns := make([]PatternSummary, 0, len(patternCounts))
+	for _, ps := range patternCounts {
+		patterns = append(patterns, *ps)
+	}
+	// Simple insertion sort (small N).
+	for i := 1; i < len(patterns); i++ {
+		for j := i; j > 0 && patterns[j].Count > patterns[j-1].Count; j-- {
+			patterns[j], patterns[j-1] = patterns[j-1], patterns[j]
+		}
+	}
+	if len(patterns) > limit {
+		patterns = patterns[:limit]
+	}
+	return patterns
+}
+
+// recentEvents returns up to max most-recent events, newest first.
+func (l *Logger) recentEvents(max int) []Event {
+	recent := make([]Event, 0, max)
+	for i := l.count - 1; i >= 0 && len(recent) < max; i-- {
+		recent = append(recent, l.events[l.ringIndex(i)])
+	}
+	return recent
+}
+
 // Report generates a summary of all recorded desire path events.
 func (l *Logger) Report() Report {
 	l.mu.RLock()
@@ -137,58 +197,15 @@ func (l *Logger) Report() Report {
 		ByParam:     make(map[string]int),
 	}
 
-	// Pattern key: rule|tool|param
-	type patternKey struct {
-		rule, tool, param string
-	}
 	patternCounts := make(map[patternKey]*PatternSummary)
-
 	for i := 0; i < l.count; i++ {
-		idx := (l.writePos - l.count + i + l.maxSize) % l.maxSize
-		event := l.events[idx]
-
-		report.ByRule[event.Rule]++
-		report.ByTool[event.Tool]++
-		report.ByParam[event.Parameter]++
-
-		key := patternKey{event.Rule, event.Tool, event.Parameter}
-		if ps, ok := patternCounts[key]; ok {
-			ps.Count++
-		} else {
-			patternCounts[key] = &PatternSummary{
-				Rule:      event.Rule,
-				Tool:      event.Tool,
-				Parameter: event.Parameter,
-				Example:   event.RawValue + " -> " + event.NormalizedTo,
-				Count:     1,
-			}
-		}
+		event := l.events[l.ringIndex(i)]
+		tallyByDimension(&report, event)
+		recordPattern(patternCounts, event)
 	}
 
-	// Sort patterns by count (descending), take top 10
-	patterns := make([]PatternSummary, 0, len(patternCounts))
-	for _, ps := range patternCounts {
-		patterns = append(patterns, *ps)
-	}
-	// Simple insertion sort (small N)
-	for i := 1; i < len(patterns); i++ {
-		for j := i; j > 0 && patterns[j].Count > patterns[j-1].Count; j-- {
-			patterns[j], patterns[j-1] = patterns[j-1], patterns[j]
-		}
-	}
-	if len(patterns) > 10 {
-		patterns = patterns[:10]
-	}
-	report.TopPatterns = patterns
-
-	// Add 5 most recent events
-	recent := make([]Event, 0, 5)
-	for i := l.count - 1; i >= 0 && len(recent) < 5; i-- {
-		idx := (l.writePos - l.count + i + l.maxSize) % l.maxSize
-		recent = append(recent, l.events[idx])
-	}
-	report.RecentOnes = recent
-
+	report.TopPatterns = topPatterns(patternCounts, 10)
+	report.RecentOnes = l.recentEvents(5)
 	return report
 }
 

--- a/miro/diagrams/errors.go
+++ b/miro/diagrams/errors.go
@@ -172,38 +172,99 @@ func ParseDiagramSyntaxError(line int, content string, reason string) *DiagramEr
 	).WithLine(line).WithInput(content).WithSuggestion("Check Mermaid syntax at https://mermaid.js.org/syntax/flowchart.html")
 }
 
+// looksLikeMisformattedArrow reports whether the input uses '->' without the
+// flowchart '-->' or sequence '->>' arrow forms.
+func looksLikeMisformattedArrow(input string) bool {
+	return strings.Contains(input, "->") && !strings.Contains(input, "-->")
+}
+
+// hasSubgraphWithoutFlowchartHeader reports whether 'subgraph' appears without
+// a flowchart/graph header.
+func hasSubgraphWithoutFlowchartHeader(input string) bool {
+	if !strings.Contains(input, "subgraph") {
+		return false
+	}
+	return !strings.HasPrefix(input, "flowchart") && !strings.HasPrefix(input, "graph")
+}
+
+// arrowHint returns the appropriate arrow-syntax hint.
+func arrowHint(input string) string {
+	if strings.Contains(input, "sequencediagram") {
+		return "Sequence diagrams use '->>': A->>B: message"
+	}
+	return "Flowcharts use '-->': A --> B"
+}
+
 // DiagramTypeHint returns a helpful hint based on the input content.
 func DiagramTypeHint(input string) string {
 	input = strings.ToLower(strings.TrimSpace(input))
 
-	// Check for common mistakes
-	if strings.Contains(input, "->") && !strings.Contains(input, "-->") {
-		if strings.Contains(input, "sequencediagram") {
-			return "Sequence diagrams use '->>': A->>B: message"
-		}
-		return "Flowcharts use '-->': A --> B"
+	if looksLikeMisformattedArrow(input) {
+		return arrowHint(input)
 	}
-
 	if strings.Contains(input, "participant") && !strings.HasPrefix(input, "sequencediagram") {
 		return "Sequence diagrams must start with 'sequenceDiagram'"
 	}
-
-	if strings.Contains(input, "subgraph") && !strings.HasPrefix(input, "flowchart") && !strings.HasPrefix(input, "graph") {
+	if hasSubgraphWithoutFlowchartHeader(input) {
 		return "Flowcharts with subgraphs must start with 'flowchart TB' or 'graph TD'"
 	}
-
 	return ""
+}
+
+// checkLineLengths returns the first offending-line error, or nil.
+func checkLineLengths(lines []string) error {
+	for i, line := range lines {
+		if len(line) > MaxLineLength {
+			return ErrLineTooLongError(i+1, len(line))
+		}
+	}
+	return nil
+}
+
+// isValidHeaderLine reports whether the line (already lowercase-trimmed)
+// is one of the supported diagram headers.
+func isValidHeaderLine(lineLower string) bool {
+	return strings.HasPrefix(lineLower, "flowchart") ||
+		strings.HasPrefix(lineLower, "graph") ||
+		lineLower == "sequencediagram"
+}
+
+// missingHeaderError builds the structured error for a missing/invalid header.
+func missingHeaderError(input string) error {
+	err := NewDiagramError(
+		ErrCodeMissingHeader,
+		"diagram must start with a valid header",
+	).WithSuggestion("Use 'flowchart TB', 'flowchart LR', 'graph TD', or 'sequenceDiagram'")
+
+	if hint := DiagramTypeHint(input); hint != "" {
+		err.Suggestion += ". " + hint
+	}
+	return err
+}
+
+// validateHeader scans the first non-empty, non-comment line for a valid
+// diagram header.
+func validateHeader(lines []string, input string) error {
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "%%") {
+			continue
+		}
+		if isValidHeaderLine(strings.ToLower(line)) {
+			return nil
+		}
+		return missingHeaderError(input)
+	}
+	return nil
 }
 
 // ValidateDiagramInput performs validation on diagram input including ReDoS protection.
 func ValidateDiagramInput(input string) error {
-	// Check total input size (ReDoS protection)
 	if len(input) > MaxDiagramInputSize {
 		return ErrInputTooLarge
 	}
 
 	input = strings.TrimSpace(input)
-
 	if input == "" {
 		return ErrEmptyDiagram
 	}
@@ -212,46 +273,11 @@ func ValidateDiagramInput(input string) error {
 	if len(lines) == 0 {
 		return ErrEmptyDiagram
 	}
-
-	// Check line count (ReDoS protection)
 	if len(lines) > MaxDiagramLines {
 		return ErrTooManyLinesError(len(lines))
 	}
-
-	// Check individual line lengths (ReDoS protection)
-	for i, line := range lines {
-		if len(line) > MaxLineLength {
-			return ErrLineTooLongError(i+1, len(line))
-		}
-	}
-
-	// Check first non-empty, non-comment line
-	for _, line := range lines {
-		line = strings.TrimSpace(line)
-		if line == "" || strings.HasPrefix(line, "%%") {
-			continue
-		}
-
-		lineLower := strings.ToLower(line)
-		if strings.HasPrefix(lineLower, "flowchart") ||
-			strings.HasPrefix(lineLower, "graph") ||
-			lineLower == "sequencediagram" {
-			return nil // Valid header found
-		}
-
-		// No valid header found
-		hint := DiagramTypeHint(input)
-		err := NewDiagramError(
-			ErrCodeMissingHeader,
-			"diagram must start with a valid header",
-		).WithSuggestion("Use 'flowchart TB', 'flowchart LR', 'graph TD', or 'sequenceDiagram'")
-
-		if hint != "" {
-			err.Suggestion += ". " + hint
-		}
-
+	if err := checkLineLengths(lines); err != nil {
 		return err
 	}
-
-	return nil
+	return validateHeader(lines, input)
 }

--- a/miro/diagrams/layout.go
+++ b/miro/diagrams/layout.go
@@ -47,47 +47,69 @@ func Layout(diagram *Diagram, config LayoutConfig) {
 	calculateBounds(diagram)
 }
 
-// assignLayers assigns each node to a layer using longest path.
-func assignLayers(diagram *Diagram) map[int][]string {
-	// Build adjacency list
-	outgoing := make(map[string][]string)
-	incoming := make(map[string][]string)
+// adjacency holds outgoing/incoming neighbor lists for a diagram's nodes.
+type adjacency struct {
+	outgoing map[string][]string
+	incoming map[string][]string
+}
+
+// buildAdjacency constructs outgoing/incoming adjacency maps, skipping edges
+// that reference unknown nodes.
+func buildAdjacency(diagram *Diagram) adjacency {
+	adj := adjacency{
+		outgoing: make(map[string][]string),
+		incoming: make(map[string][]string),
+	}
 
 	for id := range diagram.Nodes {
-		outgoing[id] = []string{}
-		incoming[id] = []string{}
+		adj.outgoing[id] = []string{}
+		adj.incoming[id] = []string{}
 	}
 
 	for _, edge := range diagram.Edges {
-		if _, ok := diagram.Nodes[edge.FromID]; !ok {
+		if !edgeRefersToKnownNodes(diagram, edge) {
 			continue
 		}
-		if _, ok := diagram.Nodes[edge.ToID]; !ok {
-			continue
-		}
-		outgoing[edge.FromID] = append(outgoing[edge.FromID], edge.ToID)
-		incoming[edge.ToID] = append(incoming[edge.ToID], edge.FromID)
+		adj.outgoing[edge.FromID] = append(adj.outgoing[edge.FromID], edge.ToID)
+		adj.incoming[edge.ToID] = append(adj.incoming[edge.ToID], edge.FromID)
 	}
 
-	// Find root nodes (no incoming edges)
+	return adj
+}
+
+func edgeRefersToKnownNodes(diagram *Diagram, edge *Edge) bool {
+	if _, ok := diagram.Nodes[edge.FromID]; !ok {
+		return false
+	}
+	if _, ok := diagram.Nodes[edge.ToID]; !ok {
+		return false
+	}
+	return true
+}
+
+// findRoots returns nodes with no incoming edges. If none exist, returns one
+// arbitrary node so layer assignment can still proceed.
+func findRoots(diagram *Diagram, incoming map[string][]string) []string {
 	var roots []string
 	for id := range diagram.Nodes {
 		if len(incoming[id]) == 0 {
 			roots = append(roots, id)
 		}
 	}
-
-	// If no roots, pick first node
-	if len(roots) == 0 {
-		for id := range diagram.Nodes {
-			roots = append(roots, id)
-			break
-		}
+	if len(roots) > 0 {
+		return roots
 	}
+	for id := range diagram.Nodes {
+		return []string{id}
+	}
+	return roots
+}
 
-	// Assign layers using BFS from roots
+// bfsLayers walks the graph from each root, assigning longest-path layer
+// numbers along outgoing edges.
+func bfsLayers(roots []string, outgoing map[string][]string) map[string]int {
 	nodeLayer := make(map[string]int)
-	queue := make([]string, 0)
+	queue := make([]string, 0, len(roots))
 	for _, root := range roots {
 		nodeLayer[root] = 0
 		queue = append(queue, root)
@@ -97,178 +119,197 @@ func assignLayers(diagram *Diagram) map[int][]string {
 		node := queue[0]
 		queue = queue[1:]
 		layer := nodeLayer[node]
-
 		for _, neighbor := range outgoing[node] {
 			newLayer := layer + 1
-			if existingLayer, ok := nodeLayer[neighbor]; !ok || existingLayer < newLayer {
+			if existing, ok := nodeLayer[neighbor]; !ok || existing < newLayer {
 				nodeLayer[neighbor] = newLayer
 				queue = append(queue, neighbor)
 			}
 		}
 	}
 
-	// Handle nodes not reached (disconnected components)
-	for id := range diagram.Nodes {
-		if _, ok := nodeLayer[id]; !ok {
-			nodeLayer[id] = 0
-		}
+	// Disconnected components default to layer 0.
+	for id := range nodeLayer {
+		_ = id
 	}
+	return nodeLayer
+}
 
-	// Group nodes by layer
+// groupByLayer collapses a per-node layer map into a layer-indexed slice of
+// node IDs.
+func groupByLayer(diagram *Diagram, nodeLayer map[string]int) map[int][]string {
 	layers := make(map[int][]string)
-	for id, layer := range nodeLayer {
+	for id := range diagram.Nodes {
+		layer, ok := nodeLayer[id]
+		if !ok {
+			layer = 0
+		}
 		layers[layer] = append(layers[layer], id)
 	}
-
 	return layers
 }
 
-// orderLayers orders nodes within each layer to minimize crossings.
-func orderLayers(diagram *Diagram, layers map[int][]string) {
-	// Build adjacency for ordering
-	outgoing := make(map[string][]string)
-	incoming := make(map[string][]string)
+// assignLayers assigns each node to a layer using longest path.
+func assignLayers(diagram *Diagram) map[int][]string {
+	adj := buildAdjacency(diagram)
+	roots := findRoots(diagram, adj.incoming)
+	nodeLayer := bfsLayers(roots, adj.outgoing)
+	return groupByLayer(diagram, nodeLayer)
+}
 
-	for id := range diagram.Nodes {
-		outgoing[id] = []string{}
-		incoming[id] = []string{}
-	}
-
-	for _, edge := range diagram.Edges {
-		if _, ok := diagram.Nodes[edge.FromID]; !ok {
-			continue
-		}
-		if _, ok := diagram.Nodes[edge.ToID]; !ok {
-			continue
-		}
-		outgoing[edge.FromID] = append(outgoing[edge.FromID], edge.ToID)
-		incoming[edge.ToID] = append(incoming[edge.ToID], edge.FromID)
-	}
-
-	// Get sorted layer indices
+// sortedLayerNums returns layer indices in ascending order.
+func sortedLayerNums(layers map[int][]string) []int {
 	layerNums := make([]int, 0, len(layers))
 	for l := range layers {
 		layerNums = append(layerNums, l)
 	}
 	sort.Ints(layerNums)
+	return layerNums
+}
 
-	// Simple barycenter ordering
+// initialBarycenter assigns each node its current position within its layer.
+func initialBarycenter(layers map[int][]string, layerNums []int) map[string]float64 {
 	nodePos := make(map[string]float64)
-
-	// Initial positions
 	for _, l := range layerNums {
 		for i, id := range layers[l] {
 			nodePos[id] = float64(i)
 		}
 	}
+	return nodePos
+}
 
-	// Iterate to improve ordering
-	for iter := 0; iter < 4; iter++ {
-		// Forward pass
+// reorderLayer recomputes each node's barycenter as the mean of its neighbors'
+// positions, sorts the layer, and snaps positions to integer indices.
+func reorderLayer(layer []string, neighbors map[string][]string, nodePos map[string]float64) {
+	for _, id := range layer {
+		ns := neighbors[id]
+		if len(ns) == 0 {
+			continue
+		}
+		sum := 0.0
+		for _, n := range ns {
+			sum += nodePos[n]
+		}
+		nodePos[id] = sum / float64(len(ns))
+	}
+
+	sort.Slice(layer, func(a, b int) bool {
+		return nodePos[layer[a]] < nodePos[layer[b]]
+	})
+
+	for j, id := range layer {
+		nodePos[id] = float64(j)
+	}
+}
+
+// orderLayers orders nodes within each layer to minimize crossings.
+func orderLayers(diagram *Diagram, layers map[int][]string) {
+	adj := buildAdjacency(diagram)
+	layerNums := sortedLayerNums(layers)
+	nodePos := initialBarycenter(layers, layerNums)
+
+	const barycenterIterations = 4
+	for iter := 0; iter < barycenterIterations; iter++ {
+		// Forward pass: order by predecessors.
 		for i := 1; i < len(layerNums); i++ {
-			l := layerNums[i]
-			for _, id := range layers[l] {
-				preds := incoming[id]
-				if len(preds) > 0 {
-					sum := 0.0
-					for _, pred := range preds {
-						sum += nodePos[pred]
-					}
-					nodePos[id] = sum / float64(len(preds))
-				}
-			}
-
-			// Sort layer by barycenter
-			sort.Slice(layers[l], func(a, b int) bool {
-				return nodePos[layers[l][a]] < nodePos[layers[l][b]]
-			})
-
-			// Update positions
-			for j, id := range layers[l] {
-				nodePos[id] = float64(j)
-			}
+			reorderLayer(layers[layerNums[i]], adj.incoming, nodePos)
 		}
-
-		// Backward pass
+		// Backward pass: order by successors.
 		for i := len(layerNums) - 2; i >= 0; i-- {
-			l := layerNums[i]
-			for _, id := range layers[l] {
-				succs := outgoing[id]
-				if len(succs) > 0 {
-					sum := 0.0
-					for _, succ := range succs {
-						sum += nodePos[succ]
-					}
-					nodePos[id] = sum / float64(len(succs))
-				}
-			}
-
-			// Sort layer by barycenter
-			sort.Slice(layers[l], func(a, b int) bool {
-				return nodePos[layers[l][a]] < nodePos[layers[l][b]]
-			})
-
-			// Update positions
-			for j, id := range layers[l] {
-				nodePos[id] = float64(j)
-			}
+			reorderLayer(layers[layerNums[i]], adj.outgoing, nodePos)
 		}
+	}
+}
+
+// maxLayerSize returns the largest layer size, used to center smaller layers.
+func maxLayerSize(layers map[int][]string) int {
+	maxN := 0
+	for _, nodes := range layers {
+		if len(nodes) > maxN {
+			maxN = len(nodes)
+		}
+	}
+	return maxN
+}
+
+// positionParams bundles values reused across per-node positioning.
+type positionParams struct {
+	config        LayoutConfig
+	isHorizontal  bool
+	isReversed    bool
+	layerCount    int
+	maxLayerWidth int
+}
+
+func makePositionParams(diagram *Diagram, layers map[int][]string, config LayoutConfig) positionParams {
+	return positionParams{
+		config:        config,
+		isHorizontal:  diagram.Direction == LeftToRight || diagram.Direction == RightToLeft,
+		isReversed:    diagram.Direction == BottomToTop || diagram.Direction == RightToLeft,
+		layerCount:    len(layers),
+		maxLayerWidth: maxLayerSize(layers),
+	}
+}
+
+// nodePlacement captures where a node should land within its layer.
+type nodePlacement struct {
+	layerIndex int
+	nodeIndex  int
+	layerSize  int
+}
+
+// placeNode writes X/Y/Width/Height onto a single node.
+func placeNode(node *Node, np nodePlacement, p positionParams) {
+	node.Width = p.config.NodeWidth
+	node.Height = p.config.NodeHeight
+
+	layerWidth := float64(np.layerSize) * (p.config.NodeWidth + p.config.NodeSpacingX)
+	maxWidth := float64(p.maxLayerWidth) * (p.config.NodeWidth + p.config.NodeSpacingX)
+	offset := (maxWidth - layerWidth) / 2
+
+	li := float64(np.layerIndex)
+	ni := float64(np.nodeIndex)
+
+	if p.isHorizontal {
+		node.X = p.config.StartX + li*(p.config.NodeWidth+p.config.NodeSpacingY)
+		node.Y = p.config.StartY + offset + ni*(p.config.NodeHeight+p.config.NodeSpacingX)
+		return
+	}
+	node.X = p.config.StartX + offset + ni*(p.config.NodeWidth+p.config.NodeSpacingX)
+	node.Y = p.config.StartY + li*(p.config.NodeHeight+p.config.NodeSpacingY)
+}
+
+// effectiveLayerIndex flips the layer order when the diagram direction is
+// reversed (BottomToTop / RightToLeft).
+func effectiveLayerIndex(rawLayer int, p positionParams) int {
+	if p.isReversed {
+		return p.layerCount - 1 - rawLayer
+	}
+	return rawLayer
+}
+
+// positionLayer places every node in a single layer.
+func positionLayer(diagram *Diagram, layerKey int, nodes []string, p positionParams) {
+	layerIndex := effectiveLayerIndex(layerKey, p)
+	for i, nodeID := range nodes {
+		node := diagram.Nodes[nodeID]
+		if node == nil {
+			continue
+		}
+		placeNode(node, nodePlacement{
+			layerIndex: layerIndex,
+			nodeIndex:  i,
+			layerSize:  len(nodes),
+		}, p)
 	}
 }
 
 // positionNodes calculates actual x,y positions for nodes.
 func positionNodes(diagram *Diagram, layers map[int][]string, config LayoutConfig) {
-	// Get sorted layer indices
-	layerNums := make([]int, 0, len(layers))
-	for l := range layers {
-		layerNums = append(layerNums, l)
-	}
-	sort.Ints(layerNums)
-
-	// Calculate max width of any layer
-	maxLayerWidth := 0
-	for _, nodes := range layers {
-		if len(nodes) > maxLayerWidth {
-			maxLayerWidth = len(nodes)
-		}
-	}
-
-	// Position based on direction
-	isHorizontal := diagram.Direction == LeftToRight || diagram.Direction == RightToLeft
-	isReversed := diagram.Direction == BottomToTop || diagram.Direction == RightToLeft
-
+	layerNums := sortedLayerNums(layers)
+	p := makePositionParams(diagram, layers, config)
 	for _, l := range layerNums {
-		nodes := layers[l]
-		layerIndex := l
-		if isReversed {
-			layerIndex = len(layerNums) - 1 - l
-		}
-
-		for i, nodeID := range nodes {
-			node := diagram.Nodes[nodeID]
-			if node == nil {
-				continue
-			}
-
-			// Set node dimensions
-			node.Width = config.NodeWidth
-			node.Height = config.NodeHeight
-
-			// Calculate position
-			nodeIndex := float64(i)
-
-			// Center the layer
-			layerWidth := float64(len(nodes)) * (config.NodeWidth + config.NodeSpacingX)
-			offset := (float64(maxLayerWidth)*(config.NodeWidth+config.NodeSpacingX) - layerWidth) / 2
-
-			if isHorizontal {
-				node.X = config.StartX + float64(layerIndex)*(config.NodeWidth+config.NodeSpacingY)
-				node.Y = config.StartY + offset + nodeIndex*(config.NodeHeight+config.NodeSpacingX)
-			} else {
-				node.X = config.StartX + offset + nodeIndex*(config.NodeWidth+config.NodeSpacingX)
-				node.Y = config.StartY + float64(layerIndex)*(config.NodeHeight+config.NodeSpacingY)
-			}
-		}
+		positionLayer(diagram, l, layers[l], p)
 	}
 }
 

--- a/miro/diagrams/sequence.go
+++ b/miro/diagrams/sequence.go
@@ -149,37 +149,56 @@ func isIgnorableLine(line string) bool {
 	return line == "" || strings.HasPrefix(line, "%%")
 }
 
+// tryParseHeader marks the header as found when line matches the header
+// pattern.
+func (p *SequenceParser) tryParseHeader(line string, state *parseState) bool {
+	if !p.headerPattern.MatchString(line) {
+		return false
+	}
+	state.foundHeader = true
+	return true
+}
+
+// tryParseLoopStart pushes a new group onto the stack when line opens a loop.
+func (p *SequenceParser) tryParseLoopStart(line string, state *parseState) bool {
+	matches := p.loopStartPattern.FindStringSubmatch(line)
+	if matches == nil {
+		return false
+	}
+	state.groupStack = append(state.groupStack, strings.ToLower(matches[1]))
+	return true
+}
+
+// tryParseLoopEnd pops a group off the stack when line closes a loop.
+func (p *SequenceParser) tryParseLoopEnd(line string, state *parseState) bool {
+	if !p.loopEndPattern.MatchString(line) {
+		return false
+	}
+	if len(state.groupStack) > 0 {
+		state.groupStack = state.groupStack[:len(state.groupStack)-1]
+	}
+	return true
+}
+
 // dispatchLine matches line against each known pattern in priority order and
 // updates state accordingly. Lines that match nothing are silently dropped
 // (matches the Mermaid-permissive behavior the original Parse had).
 func (p *SequenceParser) dispatchLine(line string, state *parseState) {
-	if p.headerPattern.MatchString(line) {
-		state.foundHeader = true
-		return
+	handlers := []func(string, *parseState) bool{
+		p.tryParseHeader,
+		p.tryParseParticipant,
+		p.tryParseMessage,
+		// Notes and activation bars are visual enhancements; skipped.
+		func(l string, _ *parseState) bool { return p.notePattern.MatchString(l) },
+		func(l string, _ *parseState) bool { return p.activatePattern.MatchString(l) },
+		p.tryParseLoopStart,
+		func(l string, _ *parseState) bool { return p.elsePattern.MatchString(l) },
+		p.tryParseLoopEnd,
 	}
-	if p.tryParseParticipant(line, state) {
-		return
-	}
-	if p.tryParseMessage(line, state) {
-		return
-	}
-	if p.notePattern.MatchString(line) {
-		// Notes are visual enhancements; skipped in basic implementation.
-		return
-	}
-	if p.activatePattern.MatchString(line) {
-		// Activation bars are visual enhancements; skipped.
-		return
-	}
-	if matches := p.loopStartPattern.FindStringSubmatch(line); matches != nil {
-		state.groupStack = append(state.groupStack, strings.ToLower(matches[1]))
-		return
-	}
-	if p.elsePattern.MatchString(line) {
-		return
-	}
-	if p.loopEndPattern.MatchString(line) && len(state.groupStack) > 0 {
-		state.groupStack = state.groupStack[:len(state.groupStack)-1]
+	for _, h := range handlers {
+		if h(line, state) {
+			return
+		}
 	}
 }
 

--- a/miro/docs.go
+++ b/miro/docs.go
@@ -145,6 +145,31 @@ func (c *Client) DeleteDocFormat(ctx context.Context, args DeleteDocFormatArgs) 
 
 // UpdateDocFormat updates a doc format item's content.
 // The Miro REST API does not support PATCH on doc_format items, so this
+// findAndReplaceContent applies a find-and-replace per ReplaceAll and returns
+// the new content plus the number of occurrences replaced.
+func findAndReplaceContent(content string, args UpdateDocFormatArgs) (string, int, error) {
+	if !strings.Contains(content, args.OldContent) {
+		return "", 0, fmt.Errorf("old_content not found in document")
+	}
+	if args.ReplaceAll {
+		count := strings.Count(content, args.OldContent)
+		return strings.ReplaceAll(content, args.OldContent, args.NewContent), count, nil
+	}
+	return strings.Replace(content, args.OldContent, args.NewContent, 1), 1, nil
+}
+
+// resolveDocFormatContent picks the new doc content based on which args are
+// set (find-and-replace vs full replacement) and validates the inputs.
+func resolveDocFormatContent(currentContent string, args UpdateDocFormatArgs) (string, int, error) {
+	if args.OldContent != "" {
+		return findAndReplaceContent(currentContent, args)
+	}
+	if args.Content != "" {
+		return args.Content, 0, nil
+	}
+	return "", 0, fmt.Errorf("either content (full replace) or old_content+new_content (find-and-replace) is required")
+}
+
 // reads the current doc, applies changes, deletes the original, and
 // recreates it at the same position with the new content.
 func (c *Client) UpdateDocFormat(ctx context.Context, args UpdateDocFormatArgs) (UpdateDocFormatResult, error) {
@@ -165,31 +190,9 @@ func (c *Client) UpdateDocFormat(ctx context.Context, args UpdateDocFormatArgs) 
 	}
 
 	// Step 2: Determine new content
-	var newContent string
-	var replaced int
-
-	if args.OldContent != "" {
-		// Find-and-replace mode
-		if args.ReplaceAll {
-			replaced = strings.Count(getResult.Content, args.OldContent)
-			newContent = strings.ReplaceAll(getResult.Content, args.OldContent, args.NewContent)
-		} else {
-			if strings.Contains(getResult.Content, args.OldContent) {
-				replaced = 1
-				newContent = strings.Replace(getResult.Content, args.OldContent, args.NewContent, 1)
-			} else {
-				return UpdateDocFormatResult{}, fmt.Errorf("old_content not found in document")
-			}
-		}
-		if replaced == 0 {
-			return UpdateDocFormatResult{}, fmt.Errorf("old_content not found in document")
-		}
-	} else if args.Content != "" {
-		// Full content replacement mode
-		newContent = args.Content
-		replaced = 0
-	} else {
-		return UpdateDocFormatResult{}, fmt.Errorf("either content (full replace) or old_content+new_content (find-and-replace) is required")
+	newContent, replaced, err := resolveDocFormatContent(getResult.Content, args)
+	if err != nil {
+		return UpdateDocFormatResult{}, err
 	}
 
 	// Step 3: Delete original

--- a/miro/document.go
+++ b/miro/document.go
@@ -136,18 +136,10 @@ func (c *Client) GetDocument(ctx context.Context, args GetDocumentArgs) (GetDocu
 	return result, nil
 }
 
-// UpdateDocument updates a document using the dedicated documents endpoint.
-func (c *Client) UpdateDocument(ctx context.Context, args UpdateDocumentArgs) (UpdateDocumentResult, error) {
-	if err := ValidateBoardID(args.BoardID); err != nil {
-		return UpdateDocumentResult{}, err
-	}
-	if err := ValidateItemID(args.ItemID); err != nil {
-		return UpdateDocumentResult{}, fmt.Errorf("invalid item_id: %w", err)
-	}
-
+// buildUpdateDocumentBody assembles the PATCH body for a document update.
+func buildUpdateDocumentBody(args UpdateDocumentArgs) map[string]interface{} {
 	reqBody := make(map[string]interface{})
 
-	// Build data section
 	data := make(map[string]interface{})
 	if args.Title != nil {
 		data["title"] = *args.Title
@@ -159,34 +151,26 @@ func (c *Client) UpdateDocument(ctx context.Context, args UpdateDocumentArgs) (U
 		reqBody["data"] = data
 	}
 
-	// Build position section
-	if args.X != nil || args.Y != nil {
-		pos := map[string]interface{}{"origin": "center"}
-		if args.X != nil {
-			pos["x"] = *args.X
-		}
-		if args.Y != nil {
-			pos["y"] = *args.Y
-		}
+	if pos := buildPositionSection(args.X, args.Y); pos != nil {
 		reqBody["position"] = pos
 	}
-
-	// Build geometry section
 	if args.Width != nil {
-		reqBody["geometry"] = map[string]interface{}{
-			"width": *args.Width,
-		}
+		reqBody["geometry"] = map[string]interface{}{"width": *args.Width}
+	}
+	applyParentField(reqBody, args.ParentID)
+	return reqBody
+}
+
+// UpdateDocument updates a document using the dedicated documents endpoint.
+func (c *Client) UpdateDocument(ctx context.Context, args UpdateDocumentArgs) (UpdateDocumentResult, error) {
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return UpdateDocumentResult{}, err
+	}
+	if err := ValidateItemID(args.ItemID); err != nil {
+		return UpdateDocumentResult{}, fmt.Errorf("invalid item_id: %w", err)
 	}
 
-	// Build parent section
-	if args.ParentID != nil {
-		if *args.ParentID == "" {
-			reqBody["parent"] = nil
-		} else {
-			reqBody["parent"] = map[string]interface{}{"id": *args.ParentID}
-		}
-	}
-
+	reqBody := buildUpdateDocumentBody(args)
 	if len(reqBody) == 0 {
 		return UpdateDocumentResult{
 			ID:      args.ItemID,

--- a/miro/embed.go
+++ b/miro/embed.go
@@ -78,18 +78,26 @@ func (c *Client) CreateEmbed(ctx context.Context, args CreateEmbedArgs) (CreateE
 	}, nil
 }
 
-// UpdateEmbed updates an embed using the dedicated embeds endpoint.
-func (c *Client) UpdateEmbed(ctx context.Context, args UpdateEmbedArgs) (UpdateEmbedResult, error) {
-	if err := ValidateBoardID(args.BoardID); err != nil {
-		return UpdateEmbedResult{}, err
+// buildWHGeometry returns a geometry map containing width and/or height when
+// either is set.
+func buildWHGeometry(width, height *float64) map[string]interface{} {
+	geom := make(map[string]interface{})
+	if width != nil {
+		geom["width"] = *width
 	}
-	if err := ValidateItemID(args.ItemID); err != nil {
-		return UpdateEmbedResult{}, fmt.Errorf("invalid item_id: %w", err)
+	if height != nil {
+		geom["height"] = *height
 	}
+	if len(geom) == 0 {
+		return nil
+	}
+	return geom
+}
 
+// buildUpdateEmbedBody assembles the PATCH body for an embed update.
+func buildUpdateEmbedBody(args UpdateEmbedArgs) map[string]interface{} {
 	reqBody := make(map[string]interface{})
 
-	// Build data section
 	data := make(map[string]interface{})
 	if args.URL != nil {
 		data["url"] = *args.URL
@@ -101,39 +109,26 @@ func (c *Client) UpdateEmbed(ctx context.Context, args UpdateEmbedArgs) (UpdateE
 		reqBody["data"] = data
 	}
 
-	// Build position section
-	if args.X != nil || args.Y != nil {
-		pos := map[string]interface{}{"origin": "center"}
-		if args.X != nil {
-			pos["x"] = *args.X
-		}
-		if args.Y != nil {
-			pos["y"] = *args.Y
-		}
+	if pos := buildPositionSection(args.X, args.Y); pos != nil {
 		reqBody["position"] = pos
 	}
-
-	// Build geometry section
-	geom := make(map[string]interface{})
-	if args.Width != nil {
-		geom["width"] = *args.Width
-	}
-	if args.Height != nil {
-		geom["height"] = *args.Height
-	}
-	if len(geom) > 0 {
+	if geom := buildWHGeometry(args.Width, args.Height); geom != nil {
 		reqBody["geometry"] = geom
 	}
+	applyParentField(reqBody, args.ParentID)
+	return reqBody
+}
 
-	// Build parent section
-	if args.ParentID != nil {
-		if *args.ParentID == "" {
-			reqBody["parent"] = nil
-		} else {
-			reqBody["parent"] = map[string]interface{}{"id": *args.ParentID}
-		}
+// UpdateEmbed updates an embed using the dedicated embeds endpoint.
+func (c *Client) UpdateEmbed(ctx context.Context, args UpdateEmbedArgs) (UpdateEmbedResult, error) {
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return UpdateEmbedResult{}, err
+	}
+	if err := ValidateItemID(args.ItemID); err != nil {
+		return UpdateEmbedResult{}, fmt.Errorf("invalid item_id: %w", err)
 	}
 
+	reqBody := buildUpdateEmbedBody(args)
 	if len(reqBody) == 0 {
 		return UpdateEmbedResult{
 			ID:      args.ItemID,

--- a/miro/errors.go
+++ b/miro/errors.go
@@ -61,33 +61,33 @@ func (e *APIError) IsServerError() bool {
 // feedbackURL is the pre-filled issue link shown on setup/auth errors.
 const feedbackURL = "https://github.com/olgasafonova/miro-mcp-server/issues/new?template=bug_report.yml"
 
+// staticSuggestions maps status codes to non-parameterized suggestion text.
+var staticSuggestions = map[int]string{
+	http.StatusUnauthorized:        "Check that MIRO_ACCESS_TOKEN is set and valid. Get a token at https://miro.com/app/settings/user-profile/apps — Still stuck? " + feedbackURL,
+	http.StatusForbidden:           "Your token may lack the required scopes. Check board sharing permissions or regenerate your token with correct scopes. Still stuck? " + feedbackURL,
+	http.StatusNotFound:            "The board or item may have been deleted, or the ID may be incorrect. Verify the ID exists.",
+	http.StatusBadRequest:          "Check that all required parameters are provided and valid.",
+	http.StatusConflict:            "The operation conflicts with the current state. The resource may already exist.",
+	413:                            "Request payload is too large. Reduce content size or split into multiple requests.",
+	http.StatusInternalServerError: "Miro API server error. Try again later.",
+	http.StatusServiceUnavailable:  "Miro API is temporarily unavailable. Try again in a few minutes.",
+}
+
+// rateLimitSuggestion produces the 429 message, formatted with RetryAfter
+// when present.
+func (e *APIError) rateLimitSuggestion() string {
+	if e.RetryAfter > 0 {
+		return fmt.Sprintf("Rate limit exceeded. Wait %d seconds before retrying.", e.RetryAfter)
+	}
+	return "Rate limit exceeded. Wait a moment before retrying, or reduce request frequency."
+}
+
 // Suggestion returns actionable guidance for resolving the error.
 func (e *APIError) Suggestion() string {
-	switch e.StatusCode {
-	case http.StatusUnauthorized:
-		return "Check that MIRO_ACCESS_TOKEN is set and valid. Get a token at https://miro.com/app/settings/user-profile/apps — Still stuck? " + feedbackURL
-	case http.StatusForbidden:
-		return "Your token may lack the required scopes. Check board sharing permissions or regenerate your token with correct scopes. Still stuck? " + feedbackURL
-	case http.StatusNotFound:
-		return "The board or item may have been deleted, or the ID may be incorrect. Verify the ID exists."
-	case http.StatusTooManyRequests:
-		if e.RetryAfter > 0 {
-			return fmt.Sprintf("Rate limit exceeded. Wait %d seconds before retrying.", e.RetryAfter)
-		}
-		return "Rate limit exceeded. Wait a moment before retrying, or reduce request frequency."
-	case http.StatusBadRequest:
-		return "Check that all required parameters are provided and valid."
-	case http.StatusConflict:
-		return "The operation conflicts with the current state. The resource may already exist."
-	case 413: // Request Entity Too Large
-		return "Request payload is too large. Reduce content size or split into multiple requests."
-	case http.StatusInternalServerError:
-		return "Miro API server error. Try again later."
-	case http.StatusServiceUnavailable:
-		return "Miro API is temporarily unavailable. Try again in a few minutes."
-	default:
-		return ""
+	if e.StatusCode == http.StatusTooManyRequests {
+		return e.rateLimitSuggestion()
 	}
+	return staticSuggestions[e.StatusCode]
 }
 
 // =============================================================================

--- a/miro/health.go
+++ b/miro/health.go
@@ -61,6 +61,40 @@ func NewHealthChecker(client *Client, serverName, version string) *HealthChecker
 	}
 }
 
+// shallowAPIComponent returns the cached API health for shallow checks.
+func (h *HealthChecker) shallowAPIComponent() ComponentHealth {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	if h.lastAPICheck.IsZero() {
+		return ComponentHealth{
+			Status:  HealthStatusHealthy,
+			Message: "not yet checked (use ?deep=true)",
+		}
+	}
+	return ComponentHealth{
+		Status:      h.lastAPIStatus,
+		Message:     h.lastAPIError,
+		LastChecked: h.lastAPICheck,
+		Latency:     h.lastAPILatency.String(),
+	}
+}
+
+// overallStatus rolls component statuses into a single overall verdict.
+// Any Unhealthy component flips the result to Unhealthy; otherwise a single
+// Degraded component yields Degraded; otherwise Healthy.
+func overallStatus(components map[string]ComponentHealth) HealthStatus {
+	status := HealthStatusHealthy
+	for _, comp := range components {
+		if comp.Status == HealthStatusUnhealthy {
+			return HealthStatusUnhealthy
+		}
+		if comp.Status == HealthStatusDegraded {
+			status = HealthStatusDegraded
+		}
+	}
+	return status
+}
+
 // Check performs a health check and returns a report
 // If deep is true, it also tests the Miro API connectivity
 func (h *HealthChecker) Check(ctx context.Context, deep bool) HealthReport {
@@ -74,42 +108,14 @@ func (h *HealthChecker) Check(ctx context.Context, deep bool) HealthReport {
 		Components: make(map[string]ComponentHealth),
 	}
 
-	// Config component check
 	report.Components["config"] = h.checkConfig()
-
-	// API component check (deep check)
 	if deep {
 		report.Components["miro_api"] = h.checkAPI(ctx)
 	} else {
-		// Report last known status for shallow checks
-		h.mu.RLock()
-		if h.lastAPICheck.IsZero() {
-			report.Components["miro_api"] = ComponentHealth{
-				Status:  HealthStatusHealthy,
-				Message: "not yet checked (use ?deep=true)",
-			}
-		} else {
-			report.Components["miro_api"] = ComponentHealth{
-				Status:      h.lastAPIStatus,
-				Message:     h.lastAPIError,
-				LastChecked: h.lastAPICheck,
-				Latency:     h.lastAPILatency.String(),
-			}
-		}
-		h.mu.RUnlock()
+		report.Components["miro_api"] = h.shallowAPIComponent()
 	}
 
-	// Determine overall status
-	for _, comp := range report.Components {
-		if comp.Status == HealthStatusUnhealthy {
-			report.Status = HealthStatusUnhealthy
-			break
-		}
-		if comp.Status == HealthStatusDegraded && report.Status == HealthStatusHealthy {
-			report.Status = HealthStatusDegraded
-		}
-	}
-
+	report.Status = overallStatus(report.Components)
 	return report
 }
 

--- a/miro/image.go
+++ b/miro/image.go
@@ -137,18 +137,10 @@ func (c *Client) GetImage(ctx context.Context, args GetImageArgs) (GetImageResul
 	return result, nil
 }
 
-// UpdateImage updates an image using the dedicated images endpoint.
-func (c *Client) UpdateImage(ctx context.Context, args UpdateImageArgs) (UpdateImageResult, error) {
-	if err := ValidateBoardID(args.BoardID); err != nil {
-		return UpdateImageResult{}, err
-	}
-	if err := ValidateItemID(args.ItemID); err != nil {
-		return UpdateImageResult{}, fmt.Errorf("invalid item_id: %w", err)
-	}
-
+// buildUpdateImageBody assembles the PATCH body for an image update.
+func buildUpdateImageBody(args UpdateImageArgs) map[string]interface{} {
 	reqBody := make(map[string]interface{})
 
-	// Build data section
 	data := make(map[string]interface{})
 	if args.Title != nil {
 		data["title"] = *args.Title
@@ -160,34 +152,26 @@ func (c *Client) UpdateImage(ctx context.Context, args UpdateImageArgs) (UpdateI
 		reqBody["data"] = data
 	}
 
-	// Build position section
-	if args.X != nil || args.Y != nil {
-		pos := map[string]interface{}{"origin": "center"}
-		if args.X != nil {
-			pos["x"] = *args.X
-		}
-		if args.Y != nil {
-			pos["y"] = *args.Y
-		}
+	if pos := buildPositionSection(args.X, args.Y); pos != nil {
 		reqBody["position"] = pos
 	}
-
-	// Build geometry section
 	if args.Width != nil {
-		reqBody["geometry"] = map[string]interface{}{
-			"width": *args.Width,
-		}
+		reqBody["geometry"] = map[string]interface{}{"width": *args.Width}
+	}
+	applyParentField(reqBody, args.ParentID)
+	return reqBody
+}
+
+// UpdateImage updates an image using the dedicated images endpoint.
+func (c *Client) UpdateImage(ctx context.Context, args UpdateImageArgs) (UpdateImageResult, error) {
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return UpdateImageResult{}, err
+	}
+	if err := ValidateItemID(args.ItemID); err != nil {
+		return UpdateImageResult{}, fmt.Errorf("invalid item_id: %w", err)
 	}
 
-	// Build parent section
-	if args.ParentID != nil {
-		if *args.ParentID == "" {
-			reqBody["parent"] = nil
-		} else {
-			reqBody["parent"] = map[string]interface{}{"id": *args.ParentID}
-		}
-	}
-
+	reqBody := buildUpdateImageBody(args)
 	if len(reqBody) == 0 {
 		return UpdateImageResult{
 			ID:      args.ItemID,

--- a/miro/metrics.go
+++ b/miro/metrics.go
@@ -95,30 +95,37 @@ func (m *MetricsCollector) RecordRetry() {
 	m.retriesTotal++
 }
 
+// apiErrorCategories maps explicit HTTP codes to their metrics category.
+var apiErrorCategories = map[int]string{
+	429: "rate_limit",
+	401: "auth",
+	403: "forbidden",
+	404: "not_found",
+}
+
+// categorizeAPIError returns the metrics category for an *APIError, falling
+// back to range buckets for unmapped codes.
+func categorizeAPIError(apiErr *APIError) string {
+	if cat, ok := apiErrorCategories[apiErr.StatusCode]; ok {
+		return cat
+	}
+	if apiErr.StatusCode >= 500 {
+		return "server"
+	}
+	if apiErr.StatusCode >= 400 {
+		return "client"
+	}
+	return "unknown"
+}
+
 // categorizeError categorizes an error for metrics
 func categorizeError(err error) string {
 	if err == nil {
 		return "none"
 	}
-
-	// Check for API errors
 	if apiErr, ok := err.(*APIError); ok {
-		switch {
-		case apiErr.StatusCode == 429:
-			return "rate_limit"
-		case apiErr.StatusCode == 401:
-			return "auth"
-		case apiErr.StatusCode == 403:
-			return "forbidden"
-		case apiErr.StatusCode == 404:
-			return "not_found"
-		case apiErr.StatusCode >= 500:
-			return "server"
-		case apiErr.StatusCode >= 400:
-			return "client"
-		}
+		return categorizeAPIError(apiErr)
 	}
-
 	return "unknown"
 }
 

--- a/miro/mindmaps.go
+++ b/miro/mindmaps.go
@@ -11,6 +11,16 @@ import (
 // Mindmap Operations
 // =============================================================================
 
+// shouldSendMindmapPosition reports whether the request body should include
+// an explicit position block. Root nodes (no parent) always carry position;
+// child nodes only when X or Y is non-zero, to override default stacking.
+func shouldSendMindmapPosition(args CreateMindmapNodeArgs) bool {
+	if args.ParentID == "" {
+		return true
+	}
+	return args.X != 0 || args.Y != 0
+}
+
 // CreateMindmapNode creates a mindmap node on a board.
 func (c *Client) CreateMindmapNode(ctx context.Context, args CreateMindmapNodeArgs) (CreateMindmapNodeResult, error) {
 	if err := ValidateBoardID(args.BoardID); err != nil {
@@ -55,7 +65,7 @@ func (c *Client) CreateMindmapNode(ctx context.Context, args CreateMindmapNodeAr
 	// always need it (default 0,0 if neither x nor y is given). For child nodes
 	// it's optional: when supplied, it overrides the API's default
 	// placement-on-top-of-parent so siblings don't all stack at the same point.
-	if args.ParentID == "" || args.X != 0 || args.Y != 0 {
+	if shouldSendMindmapPosition(args) {
 		reqBody["position"] = map[string]interface{}{
 			"x":      args.X,
 			"y":      args.Y,

--- a/miro/oauth/auth.go
+++ b/miro/oauth/auth.go
@@ -126,29 +126,26 @@ func (f *AuthFlow) Status(ctx context.Context) (*TokenSet, error) {
 	return tokens, nil
 }
 
+// revokeIfPresent revokes a non-empty token, logging (but not propagating)
+// failures. Empty tokens are a no-op.
+func (f *AuthFlow) revokeIfPresent(ctx context.Context, token, label string) {
+	if token == "" {
+		return
+	}
+	if err := f.provider.RevokeToken(ctx, token); err != nil {
+		f.logger.Warn("Failed to revoke "+label, "error", err)
+	}
+}
+
 // Logout revokes tokens and clears storage.
 func (f *AuthFlow) Logout(ctx context.Context) error {
-	tokens, err := f.tokenStore.Load(ctx)
-	if err == nil && tokens != nil {
-		// Revoke access token
-		if tokens.AccessToken != "" {
-			if err := f.provider.RevokeToken(ctx, tokens.AccessToken); err != nil {
-				f.logger.Warn("Failed to revoke access token", "error", err)
-			}
-		}
-		// Revoke refresh token
-		if tokens.RefreshToken != "" {
-			if err := f.provider.RevokeToken(ctx, tokens.RefreshToken); err != nil {
-				f.logger.Warn("Failed to revoke refresh token", "error", err)
-			}
-		}
+	if tokens, err := f.tokenStore.Load(ctx); err == nil && tokens != nil {
+		f.revokeIfPresent(ctx, tokens.AccessToken, "access token")
+		f.revokeIfPresent(ctx, tokens.RefreshToken, "refresh token")
 	}
-
-	// Delete stored tokens
 	if err := f.tokenStore.Delete(ctx); err != nil {
 		return fmt.Errorf("failed to delete tokens: %w", err)
 	}
-
 	f.logger.Info("Logged out successfully")
 	return nil
 }

--- a/miro/path.go
+++ b/miro/path.go
@@ -14,28 +14,42 @@ var knownPathSegments = map[string]bool{
 	"orgs": true, "users": true, "me": true, "teams": true,
 }
 
+// stripQuery returns part with any trailing "?..." removed.
+func stripQuery(part string) string {
+	if idx := indexOf(part, "?"); idx != -1 {
+		return part[:idx]
+	}
+	return part
+}
+
+// classifyPathPart returns the normalized segment for an endpoint, or "" if the
+// segment is empty after query-string stripping. Unknown segments collapse to
+// "{id}" placeholders.
+func classifyPathPart(part string) string {
+	part = stripQuery(part)
+	if part == "" {
+		return ""
+	}
+	if knownPathSegments[part] {
+		return part
+	}
+	return "{id}"
+}
+
 // extractEndpoint extracts a normalized endpoint from a path for circuit breaker.
 // For example: /boards/abc123/items/xyz -> /boards/{id}/items/{id}
 func extractEndpoint(path string) string {
 	parts := make([]string, 0)
-	for _, part := range splitPath(path) {
-		// Skip query strings
-		if idx := indexOf(part, "?"); idx != -1 {
-			part = part[:idx]
-		}
-		if part == "" {
+	for _, raw := range splitPath(path) {
+		seg := classifyPathPart(raw)
+		if seg == "" {
 			continue
 		}
-		// Check if this is a known path segment
-		if knownPathSegments[part] {
-			parts = append(parts, part)
-		} else {
-			// This is likely an ID - replace with placeholder
-			// Avoid consecutive {id} entries
-			if len(parts) == 0 || parts[len(parts)-1] != "{id}" {
-				parts = append(parts, "{id}")
-			}
+		// Avoid consecutive {id} entries.
+		if seg == "{id}" && len(parts) > 0 && parts[len(parts)-1] == "{id}" {
+			continue
 		}
+		parts = append(parts, seg)
 	}
 	return "/" + joinPath(parts)
 }

--- a/miro/path.go
+++ b/miro/path.go
@@ -36,6 +36,15 @@ func classifyPathPart(part string) string {
 	return "{id}"
 }
 
+// duplicatesLastIDPlaceholder reports whether appending seg would create
+// consecutive "{id}" placeholders.
+func duplicatesLastIDPlaceholder(parts []string, seg string) bool {
+	if seg != "{id}" || len(parts) == 0 {
+		return false
+	}
+	return parts[len(parts)-1] == "{id}"
+}
+
 // extractEndpoint extracts a normalized endpoint from a path for circuit breaker.
 // For example: /boards/abc123/items/xyz -> /boards/{id}/items/{id}
 func extractEndpoint(path string) string {
@@ -45,8 +54,7 @@ func extractEndpoint(path string) string {
 		if seg == "" {
 			continue
 		}
-		// Avoid consecutive {id} entries.
-		if seg == "{id}" && len(parts) > 0 && parts[len(parts)-1] == "{id}" {
+		if duplicatesLastIDPlaceholder(parts, seg) {
 			continue
 		}
 		parts = append(parts, seg)

--- a/miro/ratelimit.go
+++ b/miro/ratelimit.go
@@ -95,6 +95,36 @@ func NewAdaptiveRateLimiter(config RateLimiterConfig) *AdaptiveRateLimiter {
 	}
 }
 
+// parseIntHeader returns the parsed int when the header is a valid integer
+// at or above min, and (0, false) otherwise.
+func parseIntHeader(value string, min int) (int, bool) {
+	if value == "" {
+		return 0, false
+	}
+	v, err := strconv.Atoi(value)
+	if err != nil || v < min {
+		return 0, false
+	}
+	return v, true
+}
+
+// parseResetAt converts an X-RateLimit-Reset header into an absolute time.
+// Values greater than 1e9 are treated as Unix timestamps; smaller values are
+// treated as seconds-until-reset.
+func parseResetAt(value string, now time.Time) (time.Time, bool) {
+	if value == "" {
+		return time.Time{}, false
+	}
+	v, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		return time.Time{}, false
+	}
+	if v > 1000000000 {
+		return time.Unix(v, 0), true
+	}
+	return now.Add(time.Duration(v) * time.Second), true
+}
+
 // UpdateFromResponse updates the rate limit state from response headers.
 // Standard headers: X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset
 func (r *AdaptiveRateLimiter) UpdateFromResponse(resp *http.Response) {
@@ -105,31 +135,17 @@ func (r *AdaptiveRateLimiter) UpdateFromResponse(resp *http.Response) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	// Parse rate limit headers
-	if limit := resp.Header.Get("X-RateLimit-Limit"); limit != "" {
-		if v, err := strconv.Atoi(limit); err == nil && v > 0 {
-			r.state.Limit = v
-		}
+	if v, ok := parseIntHeader(resp.Header.Get("X-RateLimit-Limit"), 1); ok {
+		r.state.Limit = v
 	}
-
-	if remaining := resp.Header.Get("X-RateLimit-Remaining"); remaining != "" {
-		if v, err := strconv.Atoi(remaining); err == nil && v >= 0 {
-			r.state.Remaining = v
-		}
+	if v, ok := parseIntHeader(resp.Header.Get("X-RateLimit-Remaining"), 0); ok {
+		r.state.Remaining = v
 	}
-
-	if reset := resp.Header.Get("X-RateLimit-Reset"); reset != "" {
-		// Reset can be a Unix timestamp or seconds until reset
-		if v, err := strconv.ParseInt(reset, 10, 64); err == nil {
-			if v > 1000000000 { // Looks like a Unix timestamp
-				r.state.ResetAt = time.Unix(v, 0)
-			} else { // Seconds until reset
-				r.state.ResetAt = time.Now().Add(time.Duration(v) * time.Second)
-			}
-		}
+	now := time.Now()
+	if t, ok := parseResetAt(resp.Header.Get("X-RateLimit-Reset"), now); ok {
+		r.state.ResetAt = t
 	}
-
-	r.state.UpdatedAt = time.Now()
+	r.state.UpdatedAt = now
 }
 
 // Wait blocks until it's safe to make a request, or ctx is cancelled.
@@ -167,34 +183,38 @@ func (r *AdaptiveRateLimiter) Wait(ctx context.Context) (time.Duration, error) {
 	}
 }
 
+// proportionalSlowdownDelay computes a delay that grows as the remaining
+// budget approaches the slowdown threshold.
+func proportionalSlowdownDelay(state RateLimitState, config RateLimiterConfig) time.Duration {
+	percentRemaining := state.PercentRemaining()
+	if percentRemaining >= config.SlowdownThreshold {
+		return 0
+	}
+	ratio := 1.0 - (percentRemaining / config.SlowdownThreshold)
+	return time.Duration(float64(config.MaxDelay-config.MinDelay)*ratio) + config.MinDelay
+}
+
+// waitUntilReset returns the time remaining until ResetAt, capped at MaxDelay.
+// Returns 0 if ResetAt is unset or already in the past.
+func waitUntilReset(state RateLimitState, config RateLimiterConfig) time.Duration {
+	if state.ResetAt.IsZero() || !state.ResetAt.After(time.Now()) {
+		return 0
+	}
+	waitTime := time.Until(state.ResetAt)
+	if waitTime > config.MaxDelay {
+		return config.MaxDelay
+	}
+	return waitTime
+}
+
 // calculateDelay determines the appropriate delay based on current state.
 func (r *AdaptiveRateLimiter) calculateDelay(state RateLimitState, config RateLimiterConfig) time.Duration {
-	// If we have remaining requests above buffer, no delay needed
 	if state.Remaining > config.ProactiveBuffer {
-		percentRemaining := state.PercentRemaining()
-
-		// Only slow down if below threshold
-		if percentRemaining >= config.SlowdownThreshold {
-			return 0
-		}
-
-		// Calculate delay proportional to how close we are to the limit
-		// As remaining approaches 0, delay approaches MaxDelay
-		ratio := 1.0 - (percentRemaining / config.SlowdownThreshold)
-		delay := time.Duration(float64(config.MaxDelay-config.MinDelay)*ratio) + config.MinDelay
-		return delay
+		return proportionalSlowdownDelay(state, config)
 	}
-
-	// If remaining is at or below buffer, wait until reset
-	if !state.ResetAt.IsZero() && state.ResetAt.After(time.Now()) {
-		waitTime := time.Until(state.ResetAt)
-		if waitTime > config.MaxDelay {
-			return config.MaxDelay
-		}
-		return waitTime
+	if wait := waitUntilReset(state, config); wait > 0 {
+		return wait
 	}
-
-	// Fallback: apply max delay when at buffer threshold
 	return config.MaxDelay
 }
 

--- a/miro/retry.go
+++ b/miro/retry.go
@@ -9,25 +9,44 @@ import (
 // Retry Logic
 // =============================================================================
 
-// isRetriableError returns true if the error/status code should be retried.
-func isRetriableError(statusCode int, err error) bool {
-	// Retry on transient server errors
-	if statusCode == http.StatusBadGateway || // 502
-		statusCode == http.StatusServiceUnavailable || // 503
-		statusCode == http.StatusGatewayTimeout || // 504
-		statusCode == http.StatusTooManyRequests { // 429
-		return true
+// retriableStatusCodes lists HTTP status codes considered transient.
+var retriableStatusCodes = map[int]bool{
+	http.StatusBadGateway:         true, // 502
+	http.StatusServiceUnavailable: true, // 503
+	http.StatusGatewayTimeout:     true, // 504
+	http.StatusTooManyRequests:    true, // 429
+}
+
+// retriableNetworkErrorSubstrings names lower-level network-error markers.
+var retriableNetworkErrorSubstrings = []string{
+	"connection reset",
+	"connection refused",
+	"i/o timeout",
+	"no such host",
+	"EOF",
+}
+
+// isRetriableNetworkError reports whether err is one of the transient
+// network failures we retry.
+func isRetriableNetworkError(err error) bool {
+	if err == nil {
+		return false
 	}
-	// Retry on network errors (connection reset, timeout, etc.)
-	if err != nil {
-		errStr := err.Error()
-		return contains(errStr, "connection reset") ||
-			contains(errStr, "connection refused") ||
-			contains(errStr, "i/o timeout") ||
-			contains(errStr, "no such host") ||
-			contains(errStr, "EOF")
+	errStr := err.Error()
+	for _, sub := range retriableNetworkErrorSubstrings {
+		if contains(errStr, sub) {
+			return true
+		}
 	}
 	return false
+}
+
+// isRetriableError returns true if the error/status code should be retried.
+func isRetriableError(statusCode int, err error) bool {
+	if retriableStatusCodes[statusCode] {
+		return true
+	}
+	return isRetriableNetworkError(err)
 }
 
 // contains is a simple string contains helper.

--- a/miro/search.go
+++ b/miro/search.go
@@ -14,6 +14,73 @@ import (
 // Board Search
 // =============================================================================
 
+// searchBoardItem is the partial item shape needed for content search.
+type searchBoardItem struct {
+	ID       string `json:"id"`
+	Type     string `json:"type"`
+	Position *struct {
+		X float64 `json:"x"`
+		Y float64 `json:"y"`
+	} `json:"position"`
+	Data struct {
+		Content string `json:"content"`
+		Title   string `json:"title"`
+	} `json:"data"`
+}
+
+// searchBoardLimit clamps the user-supplied limit to the configured bounds.
+func searchBoardLimit(requested int) int {
+	if requested > 0 && requested < MaxSearchLimit {
+		return requested
+	}
+	return DefaultSearchLimit
+}
+
+// searchBoardPath builds the GET path with type/limit query parameters.
+func searchBoardPath(boardID, itemType string, limit int) string {
+	params := url.Values{}
+	if itemType != "" {
+		params.Set("type", itemType)
+	}
+	params.Set("limit", strconv.Itoa(limit))
+	return "/boards/" + boardID + "/items?" + params.Encode()
+}
+
+// boardItemMatch returns a populated ItemMatch when the item's content or
+// title contains queryLower, or nil otherwise. raw is parsed in place.
+func boardItemMatch(raw json.RawMessage, query, queryLower string) *ItemMatch {
+	var item searchBoardItem
+	if err := json.Unmarshal(raw, &item); err != nil {
+		return nil
+	}
+	content := item.Data.Content
+	if content == "" {
+		content = item.Data.Title
+	}
+	if content == "" || !strings.Contains(strings.ToLower(content), queryLower) {
+		return nil
+	}
+	match := ItemMatch{
+		ID:      item.ID,
+		Type:    item.Type,
+		Content: content,
+		Snippet: createSnippet(content, query, 50),
+	}
+	if item.Position != nil {
+		match.X = item.Position.X
+		match.Y = item.Position.Y
+	}
+	return &match
+}
+
+// searchBoardMessage composes the human-readable result message.
+func searchBoardMessage(count int, query string) string {
+	if count == 0 {
+		return fmt.Sprintf("No items found matching '%s'", query)
+	}
+	return fmt.Sprintf("Found %d items matching '%s'", count, query)
+}
+
 // SearchBoard searches for items containing specific text.
 func (c *Client) SearchBoard(ctx context.Context, args SearchBoardArgs) (SearchBoardResult, error) {
 	if err := ValidateBoardID(args.BoardID); err != nil {
@@ -23,23 +90,7 @@ func (c *Client) SearchBoard(ctx context.Context, args SearchBoardArgs) (SearchB
 		return SearchBoardResult{}, fmt.Errorf("query is required")
 	}
 
-	limit := DefaultSearchLimit
-	if args.Limit > 0 && args.Limit < MaxSearchLimit {
-		limit = args.Limit
-	}
-
-	// Fetch items from the board
-	params := url.Values{}
-	if args.Type != "" {
-		params.Set("type", args.Type)
-	}
-	params.Set("limit", strconv.Itoa(limit))
-
-	path := "/boards/" + args.BoardID + "/items"
-	if len(params) > 0 {
-		path += "?" + params.Encode()
-	}
-
+	path := searchBoardPath(args.BoardID, args.Type, searchBoardLimit(args.Limit))
 	respBody, err := c.request(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return SearchBoardResult{}, err
@@ -52,58 +103,19 @@ func (c *Client) SearchBoard(ctx context.Context, args SearchBoardArgs) (SearchB
 		return SearchBoardResult{}, fmt.Errorf("failed to parse response: %w", err)
 	}
 
-	// Search through items for matching content
 	queryLower := strings.ToLower(args.Query)
 	var matches []ItemMatch
-
 	for _, raw := range resp.Data {
-		var item struct {
-			ID       string `json:"id"`
-			Type     string `json:"type"`
-			Position *struct {
-				X float64 `json:"x"`
-				Y float64 `json:"y"`
-			} `json:"position"`
-			Data struct {
-				Content string `json:"content"`
-				Title   string `json:"title"`
-			} `json:"data"`
+		if m := boardItemMatch(raw, args.Query, queryLower); m != nil {
+			matches = append(matches, *m)
 		}
-		if err := json.Unmarshal(raw, &item); err != nil {
-			continue
-		}
-
-		// Check content and title for matches
-		content := item.Data.Content
-		if content == "" {
-			content = item.Data.Title
-		}
-
-		if content != "" && strings.Contains(strings.ToLower(content), queryLower) {
-			match := ItemMatch{
-				ID:      item.ID,
-				Type:    item.Type,
-				Content: content,
-				Snippet: createSnippet(content, args.Query, 50),
-			}
-			if item.Position != nil {
-				match.X = item.Position.X
-				match.Y = item.Position.Y
-			}
-			matches = append(matches, match)
-		}
-	}
-
-	message := fmt.Sprintf("Found %d items matching '%s'", len(matches), args.Query)
-	if len(matches) == 0 {
-		message = fmt.Sprintf("No items found matching '%s'", args.Query)
 	}
 
 	return SearchBoardResult{
 		Matches: matches,
 		Count:   len(matches),
 		Query:   args.Query,
-		Message: message,
+		Message: searchBoardMessage(len(matches), args.Query),
 	}, nil
 }
 

--- a/miro/sticky.go
+++ b/miro/sticky.go
@@ -77,18 +77,10 @@ func (c *Client) CreateSticky(ctx context.Context, args CreateStickyArgs) (Creat
 	}, nil
 }
 
-// UpdateSticky updates a sticky note using the dedicated sticky_notes endpoint.
-func (c *Client) UpdateSticky(ctx context.Context, args UpdateStickyArgs) (UpdateStickyResult, error) {
-	if err := ValidateBoardID(args.BoardID); err != nil {
-		return UpdateStickyResult{}, err
-	}
-	if err := ValidateItemID(args.ItemID); err != nil {
-		return UpdateStickyResult{}, fmt.Errorf("invalid item_id: %w", err)
-	}
-
+// buildUpdateStickyBody assembles the PATCH body for a sticky update.
+func buildUpdateStickyBody(args UpdateStickyArgs) map[string]interface{} {
 	reqBody := make(map[string]interface{})
 
-	// Build data section
 	data := make(map[string]interface{})
 	if args.Content != nil {
 		data["content"] = *args.Content
@@ -100,41 +92,32 @@ func (c *Client) UpdateSticky(ctx context.Context, args UpdateStickyArgs) (Updat
 		reqBody["data"] = data
 	}
 
-	// Build style section
 	if args.Color != nil {
-		reqBody["style"] = map[string]interface{}{
-			"fillColor": *args.Color,
-		}
+		reqBody["style"] = map[string]interface{}{"fillColor": *args.Color}
 	}
 
-	// Build position section
-	if args.X != nil || args.Y != nil {
-		pos := map[string]interface{}{"origin": "center"}
-		if args.X != nil {
-			pos["x"] = *args.X
-		}
-		if args.Y != nil {
-			pos["y"] = *args.Y
-		}
+	if pos := buildPositionSection(args.X, args.Y); pos != nil {
 		reqBody["position"] = pos
 	}
 
-	// Build geometry section
 	if args.Width != nil {
-		reqBody["geometry"] = map[string]interface{}{
-			"width": *args.Width,
-		}
+		reqBody["geometry"] = map[string]interface{}{"width": *args.Width}
 	}
 
-	// Build parent section
-	if args.ParentID != nil {
-		if *args.ParentID == "" {
-			reqBody["parent"] = nil
-		} else {
-			reqBody["parent"] = map[string]interface{}{"id": *args.ParentID}
-		}
+	applyParentField(reqBody, args.ParentID)
+	return reqBody
+}
+
+// UpdateSticky updates a sticky note using the dedicated sticky_notes endpoint.
+func (c *Client) UpdateSticky(ctx context.Context, args UpdateStickyArgs) (UpdateStickyResult, error) {
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return UpdateStickyResult{}, err
+	}
+	if err := ValidateItemID(args.ItemID); err != nil {
+		return UpdateStickyResult{}, fmt.Errorf("invalid item_id: %w", err)
 	}
 
+	reqBody := buildUpdateStickyBody(args)
 	if len(reqBody) == 0 {
 		return UpdateStickyResult{
 			ID:      args.ItemID,

--- a/miro/stickygrid.go
+++ b/miro/stickygrid.go
@@ -9,29 +9,22 @@ import (
 // Composite Create Operations
 // =============================================================================
 
-// CreateStickyGrid creates multiple sticky notes in a grid layout.
-func (c *Client) CreateStickyGrid(ctx context.Context, args CreateStickyGridArgs) (CreateStickyGridResult, error) {
-	if err := ValidateBoardID(args.BoardID); err != nil {
-		return CreateStickyGridResult{}, err
-	}
-	if len(args.Contents) == 0 {
-		return CreateStickyGridResult{}, fmt.Errorf("at least one content item is required")
-	}
-	if len(args.Contents) > 50 {
-		return CreateStickyGridResult{}, fmt.Errorf("maximum 50 stickies per grid")
-	}
-
-	// Defaults
-	columns := args.Columns
+// stickyGridDefaults applies grid column and spacing defaults to args.
+func stickyGridDefaults(args CreateStickyGridArgs) (columns int, spacing float64) {
+	columns = args.Columns
 	if columns <= 0 {
 		columns = 3
 	}
-	spacing := args.Spacing
+	spacing = args.Spacing
 	if spacing == 0 {
 		spacing = 220
 	}
+	return columns, spacing
+}
 
-	// Build items for bulk create
+// buildStickyGridItems converts contents into bulk-create items at the
+// computed grid positions.
+func buildStickyGridItems(args CreateStickyGridArgs, columns int, spacing float64) []BulkCreateItem {
 	items := make([]BulkCreateItem, len(args.Contents))
 	for i, content := range args.Contents {
 		row := i / columns
@@ -45,31 +38,68 @@ func (c *Client) CreateStickyGrid(ctx context.Context, args CreateStickyGridArgs
 			ParentID: args.ParentID,
 		}
 	}
+	return items
+}
 
-	// Create in batches of 20
+// batchEnd returns the exclusive end index for a batch starting at i.
+func batchEnd(i, batchSize, total int) int {
+	end := i + batchSize
+	if end > total {
+		end = total
+	}
+	return end
+}
+
+// bulkCreateOneBatch creates a single batch and returns its item IDs.
+func (c *Client) bulkCreateOneBatch(ctx context.Context, boardID string, items []BulkCreateItem) ([]string, error) {
+	result, err := c.BulkCreate(ctx, BulkCreateArgs{
+		BoardID: boardID,
+		Items:   items,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result.ItemIDs, nil
+}
+
+// bulkCreateInBatches calls BulkCreate in batches of batchSize and returns
+// all created item IDs. An error after the first batch yields partial
+// results; an error on the very first batch propagates.
+func (c *Client) bulkCreateInBatches(ctx context.Context, boardID string, items []BulkCreateItem, batchSize int) ([]string, error) {
 	var allIDs []string
-	for i := 0; i < len(items); i += 20 {
-		end := i + 20
-		if end > len(items) {
-			end = len(items)
-		}
-
-		result, err := c.BulkCreate(ctx, BulkCreateArgs{
-			BoardID: args.BoardID,
-			Items:   items[i:end],
-		})
+	for i := 0; i < len(items); i += batchSize {
+		ids, err := c.bulkCreateOneBatch(ctx, boardID, items[i:batchEnd(i, batchSize, len(items))])
 		if err != nil {
-			// Return partial results if some succeeded
 			if len(allIDs) > 0 {
-				break
+				return allIDs, nil
 			}
-			return CreateStickyGridResult{}, err
+			return nil, err
 		}
-		allIDs = append(allIDs, result.ItemIDs...)
+		allIDs = append(allIDs, ids...)
+	}
+	return allIDs, nil
+}
+
+// CreateStickyGrid creates multiple sticky notes in a grid layout.
+func (c *Client) CreateStickyGrid(ctx context.Context, args CreateStickyGridArgs) (CreateStickyGridResult, error) {
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return CreateStickyGridResult{}, err
+	}
+	if len(args.Contents) == 0 {
+		return CreateStickyGridResult{}, fmt.Errorf("at least one content item is required")
+	}
+	if len(args.Contents) > 50 {
+		return CreateStickyGridResult{}, fmt.Errorf("maximum 50 stickies per grid")
+	}
+
+	columns, spacing := stickyGridDefaults(args)
+	items := buildStickyGridItems(args, columns, spacing)
+	allIDs, err := c.bulkCreateInBatches(ctx, args.BoardID, items, 20)
+	if err != nil {
+		return CreateStickyGridResult{}, err
 	}
 
 	rows := (len(args.Contents) + columns - 1) / columns
-
 	return CreateStickyGridResult{
 		Created:  len(allIDs),
 		ItemIDs:  allIDs,

--- a/miro/text.go
+++ b/miro/text.go
@@ -80,25 +80,8 @@ func (c *Client) CreateText(ctx context.Context, args CreateTextArgs) (CreateTex
 	}, nil
 }
 
-// UpdateText updates a text item using the dedicated text endpoint.
-func (c *Client) UpdateText(ctx context.Context, args UpdateTextArgs) (UpdateTextResult, error) {
-	if err := ValidateBoardID(args.BoardID); err != nil {
-		return UpdateTextResult{}, err
-	}
-	if err := ValidateItemID(args.ItemID); err != nil {
-		return UpdateTextResult{}, fmt.Errorf("invalid item_id: %w", err)
-	}
-
-	reqBody := make(map[string]interface{})
-
-	// Build data section
-	if args.Content != nil {
-		reqBody["data"] = map[string]interface{}{
-			"content": *args.Content,
-		}
-	}
-
-	// Build style section
+// buildTextStyleSection returns the optional "style" map for a text update.
+func buildTextStyleSection(args UpdateTextArgs) (map[string]interface{}, error) {
 	style := make(map[string]interface{})
 	if args.FontSize != nil {
 		style["fontSize"] = fmt.Sprintf("%d", *args.FontSize)
@@ -109,42 +92,82 @@ func (c *Client) UpdateText(ctx context.Context, args UpdateTextArgs) (UpdateTex
 	if args.Color != nil {
 		color, err := normalizeColor(*args.Color)
 		if err != nil {
-			return UpdateTextResult{}, fmt.Errorf("color: %w", err)
+			return nil, fmt.Errorf("color: %w", err)
 		}
 		style["color"] = color
+	}
+	return style, nil
+}
+
+// buildPositionSection returns the optional "position" map when X or Y is set.
+func buildPositionSection(x, y *float64) map[string]interface{} {
+	if x == nil && y == nil {
+		return nil
+	}
+	pos := map[string]interface{}{"origin": "center"}
+	if x != nil {
+		pos["x"] = *x
+	}
+	if y != nil {
+		pos["y"] = *y
+	}
+	return pos
+}
+
+// applyParentField sets the "parent" key on reqBody if parentID is non-nil.
+// An empty string clears the parent (assigns nil).
+func applyParentField(reqBody map[string]interface{}, parentID *string) {
+	if parentID == nil {
+		return
+	}
+	if *parentID == "" {
+		reqBody["parent"] = nil
+		return
+	}
+	reqBody["parent"] = map[string]interface{}{"id": *parentID}
+}
+
+// buildUpdateTextBody assembles the full PATCH body for a text update.
+func buildUpdateTextBody(args UpdateTextArgs) (map[string]interface{}, error) {
+	reqBody := make(map[string]interface{})
+
+	if args.Content != nil {
+		reqBody["data"] = map[string]interface{}{"content": *args.Content}
+	}
+
+	style, err := buildTextStyleSection(args)
+	if err != nil {
+		return nil, err
 	}
 	if len(style) > 0 {
 		reqBody["style"] = style
 	}
 
-	// Build position section
-	if args.X != nil || args.Y != nil {
-		pos := map[string]interface{}{"origin": "center"}
-		if args.X != nil {
-			pos["x"] = *args.X
-		}
-		if args.Y != nil {
-			pos["y"] = *args.Y
-		}
+	if pos := buildPositionSection(args.X, args.Y); pos != nil {
 		reqBody["position"] = pos
 	}
 
-	// Build geometry section
 	if args.Width != nil {
-		reqBody["geometry"] = map[string]interface{}{
-			"width": *args.Width,
-		}
+		reqBody["geometry"] = map[string]interface{}{"width": *args.Width}
 	}
 
-	// Build parent section
-	if args.ParentID != nil {
-		if *args.ParentID == "" {
-			reqBody["parent"] = nil
-		} else {
-			reqBody["parent"] = map[string]interface{}{"id": *args.ParentID}
-		}
+	applyParentField(reqBody, args.ParentID)
+	return reqBody, nil
+}
+
+// UpdateText updates a text item using the dedicated text endpoint.
+func (c *Client) UpdateText(ctx context.Context, args UpdateTextArgs) (UpdateTextResult, error) {
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return UpdateTextResult{}, err
+	}
+	if err := ValidateItemID(args.ItemID); err != nil {
+		return UpdateTextResult{}, fmt.Errorf("invalid item_id: %w", err)
 	}
 
+	reqBody, err := buildUpdateTextBody(args)
+	if err != nil {
+		return UpdateTextResult{}, err
+	}
 	if len(reqBody) == 0 {
 		return UpdateTextResult{
 			ID:      args.ItemID,

--- a/prompts/prompts.go
+++ b/prompts/prompts.go
@@ -391,14 +391,20 @@ func splitString(s, sep string) []string {
 	return result
 }
 
+// isASCIIWhitespace reports whether b is one of the ASCII whitespace bytes
+// recognized by trimSpace.
+func isASCIIWhitespace(b byte) bool {
+	return b == ' ' || b == '\t' || b == '\n' || b == '\r'
+}
+
 // trimSpace removes leading/trailing whitespace
 func trimSpace(s string) string {
 	start := 0
 	end := len(s)
-	for start < end && (s[start] == ' ' || s[start] == '\t' || s[start] == '\n' || s[start] == '\r') {
+	for start < end && isASCIIWhitespace(s[start]) {
 		start++
 	}
-	for end > start && (s[end-1] == ' ' || s[end-1] == '\t' || s[end-1] == '\n' || s[end-1] == '\r') {
+	for end > start && isASCIIWhitespace(s[end-1]) {
 		end--
 	}
 	return s[start:end]


### PR DESCRIPTION
## Summary

Manual-mode codescene refactor pass — 13 commits, all 22 indication-3 findings cleared, mean code health 9.46 → 9.66 across 47 production files. Pure helper extraction; no tool schemas, no error strings, no retry semantics, no response shapes changed.

Part of experiment bead `claude-code-config-k5x` (Carlini-style parallel agent pattern applied to portfolio-wide code quality work).

## What changed

Six recurring refactor idioms:
- Bumpy Road Ahead → per-branch helper extraction (`find`, `search`, `health`, `grid/summary/auth/path`)
- Complex Method → seam-extraction (Config.Validate, Query, Report, layout algorithm)
- Code Duplication → shared section-builders (UpdateText/Sticky/Card/Document/Image/Embed)
- Excess Args → request struct (handled via shared builders above)
- Table-driven dispatch → replaced switches in DetectAction, categorizeError, isRetriableError, APIError.Suggestion
- Header parsing → `parseIntHeader`, `parseResetAt`, etc. in ratelimit

## Verified locally

- `go test ./...` — all green
- `golangci-lint run ./...` — 0 issues
- `codescene analyze_change_set` vs main — `quality_gates: passed`, all touched files verdict `improved`

## Behavior preservation

All visible UX surfaces (tool input/output schemas, error message strings, retry policy status codes + network-error substrings, rate-limit math, health check JSON shape, search result format) are byte-identical to main. Refactors are pure helper extraction.

## Refs

- Rollup: vault note `MCP Portfolio Codescene Refactor 17-05-2026`
- Bead: `claude-code-config-k5x`
- Per-repo report: `/tmp/k5x-codescene/miro-mcp-server.md`