### PR TITLE
ci: float Go to 1.25 (stop pinning exact go.mod patch)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version-file: go.mod
+          go-version: '1.25'
           cache: true
 
       - name: Verify dependencies
@@ -54,7 +54,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version-file: go.mod
+          go-version: '1.25'
           cache: true
 
       - name: Run golangci-lint
@@ -86,7 +86,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version-file: go.mod
+          go-version: '1.25'
           cache: true
 
       - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version-file: go.mod
+          go-version: '1.25'
 
       - name: Build binary
         env:


### PR DESCRIPTION
## What
Replace `go-version-file: go.mod` with `go-version: '1.25'` in CI/release workflows.

## Why
`actions/setup-go` with `go-version-file` installs the **exact** patch from the go.mod directive, so CI builds froze on a stale toolchain missing stdlib security fixes. `go-version: '1.25'` installs the latest 1.25.x, so toolchain advisories (GO-2026-5037 crypto/x509, GO-2026-5039 net/textproto; fixed in go1.26.4) flow in automatically.

CI-config only; no source changes.
