### PR TITLE
fix(share): fail closed when MIRO_SHARE_ALLOWED_EMAILS normalizes to empty

### DIFF
--- a/main.go
+++ b/main.go
@@ -231,6 +231,13 @@ func loadShareAllowlist(user *miro.UserInfo, logger *slog.Logger) *tools.ShareAl
 	}
 	shareAllowlist := tools.LoadShareAllowlistFromEnv(fallbackEmail)
 	switch {
+	case shareAllowlist.EmailSource() != "" && len(shareAllowlist.Emails()) == 0:
+		// Operator set MIRO_SHARE_ALLOWED_EMAILS to a value that normalized to
+		// nothing (e.g. "," or whitespace). Fail closed loudly rather than letting
+		// the weaker domain layer take over silently.
+		logger.Warn("miro_share_board MIRO_SHARE_ALLOWED_EMAILS is set but has no valid addresses after normalization; all share invitations will be rejected (fail-closed)",
+			"fix", "provide at least one valid email, or unset MIRO_SHARE_ALLOWED_EMAILS to use the domain allowlist",
+			"source", shareAllowlist.EmailSource())
 	case shareAllowlist.IsEmpty():
 		logger.Warn("miro_share_board allowlist is empty; all share invitations will be rejected",
 			"fix", "set MIRO_SHARE_ALLOWED_EMAILS (exact-email, tighter) or MIRO_SHARE_ALLOWED_DOMAINS (domain)",

--- a/tools/share_allowlist.go
+++ b/tools/share_allowlist.go
@@ -193,6 +193,16 @@ func (a *ShareAllowlist) IsEmpty() bool {
 	return len(a.domains) == 0 && len(a.emails) == 0
 }
 
+// emailLayerConfigured reports whether the exact-email layer was explicitly
+// configured (WithEmails was called), regardless of whether it ended up with
+// any valid entries. emailSource is set only by WithEmails, so a non-empty
+// source is the reliable "operator opted into the exact-email layer" signal.
+// A configured-but-empty layer is treated as a fail-closed misconfiguration in
+// Validate, not a silent fall-through to the weaker domain layer.
+func (a *ShareAllowlist) emailLayerConfigured() bool {
+	return a.emailSource != ""
+}
+
 // Validate checks whether email is permitted to receive a board-share
 // invitation. It returns nil on success, or a descriptive error that names the
 // offending value and the configured source so the operator can fix it.
@@ -213,7 +223,18 @@ func (a *ShareAllowlist) Validate(email string) error {
 	// Exact-email allowlist is authoritative when configured. A domain match
 	// must NOT rescue an address that is not in the exact list — that is the
 	// "approved domain" exfiltration gap this layer exists to close.
-	if len(a.emails) > 0 {
+	if a.emailLayerConfigured() {
+		// Configured but empty after normalization (e.g. MIRO_SHARE_ALLOWED_EMAILS=","
+		// or whitespace-only entries) is operator misconfiguration. Fail closed
+		// rather than silently downgrading to the weaker domain layer.
+		if len(a.emails) == 0 {
+			return fmt.Errorf(
+				"miro_share_board is blocked: %s is set (source: %s) but contains no valid "+
+					"addresses after normalization. Provide at least one valid email, or unset "+
+					"%s to fall back to the domain allowlist, and restart the server",
+				ShareEmailAllowlistEnvVar, a.emailSource, ShareEmailAllowlistEnvVar,
+			)
+		}
 		normalized := strings.ToLower(email)
 		if _, allowed := a.emails[normalized]; allowed {
 			return nil

--- a/tools/share_allowlist_test.go
+++ b/tools/share_allowlist_test.go
@@ -234,6 +234,38 @@ func TestLoadShareAllowlistFromEnv_ExactEmailAuthoritativeOverDomain(t *testing.
 	}
 }
 
+// TestShareAllowlist_ConfiguredButEmptyEmailLayerFailsClosed guards the 2xy7
+// hardening: when the exact-email layer is configured (WithEmails called) but
+// normalizes to zero entries, Validate must fail closed rather than silently
+// downgrading to the weaker domain layer. A recipient the domain layer WOULD
+// permit must still be rejected.
+func TestShareAllowlist_ConfiguredButEmptyEmailLayerFailsClosed(t *testing.T) {
+	allow := NewShareAllowlist([]string{"corp.com"}, "domain-test").
+		WithEmails([]string{" ", "", "\t"}, "email-test") // all skipped -> empty
+
+	err := allow.Validate("attacker@corp.com")
+	if err == nil {
+		t.Fatal("configured-but-empty exact-email layer must fail closed, not fall back to the domain allowlist")
+	}
+	if !strings.Contains(err.Error(), ShareEmailAllowlistEnvVar) {
+		t.Errorf("error should name the misconfigured env var; got %q", err)
+	}
+}
+
+func TestLoadShareAllowlistFromEnv_MalformedEmailValueFailsClosed(t *testing.T) {
+	// "," survives the rawEmails != "" guard (TrimSpace leaves the comma) but
+	// normalizes to zero entries. With a domain allowlist also set, the old
+	// behavior would silently permit any address in corp.com.
+	t.Setenv(ShareAllowlistEnvVar, "corp.com")
+	t.Setenv(ShareEmailAllowlistEnvVar, " , ")
+
+	allow := LoadShareAllowlistFromEnv("")
+
+	if err := allow.Validate("attacker@corp.com"); err == nil {
+		t.Fatal("malformed MIRO_SHARE_ALLOWED_EMAILS must fail closed, not fall back to the domain allowlist")
+	}
+}
+
 func TestLoadShareAllowlistFromEnv_ExactEmailOnly(t *testing.T) {
 	t.Setenv(ShareAllowlistEnvVar, "")
 	t.Setenv(ShareEmailAllowlistEnvVar, "jane@tietoevry.com, bob@tieto.com")


### PR DESCRIPTION
## What

Fails closed when `MIRO_SHARE_ALLOWED_EMAILS` is set but normalizes to zero entries (e.g. `","` or whitespace).

## Why

A value like `","` survives the `rawEmails != ""` guard in `LoadShareAllowlistFromEnv` (TrimSpace doesn't strip the comma) but `normalizeSet` yields an empty set. Previously `Validate` saw `len(emails)==0` and **silently downgraded to the domain allowlist** — so an operator who set `MIRO_SHARE_ALLOWED_EMAILS` to a malformed value got domain-level sharing with no warning, defeating the exact-email restriction they intended.

## Fix

An exact-email layer that was *configured* (`WithEmails` called → `emailSource` set) but normalized to zero entries now fails closed:
- `Validate` rejects every recipient with a message naming the misconfigured env var.
- Startup logging warns explicitly (`...has no valid addresses after normalization; all share invitations will be rejected (fail-closed)`) instead of reporting the domain layer as active.

The "configured" signal is `emailSource != ""` (set only by `WithEmails`), so a genuinely unset email layer still falls back to the domain allowlist as before.

## Provenance

Found by the **fr8l cross-vendor review trial** (Gemini 2.5 Pro) on #55. The Opus first pass saw the same code path and dismissed it as benign — a textbook same-weights blind spot. Defense-in-depth: requires operator misconfiguration *and* a domain allowlist set.

## Testing

`make check` green. Two new tests:
- `TestShareAllowlist_ConfiguredButEmptyEmailLayerFailsClosed` — a recipient the domain layer would permit is rejected.
- `TestLoadShareAllowlistFromEnv_MalformedEmailValueFailsClosed` — `MIRO_SHARE_ALLOWED_EMAILS=" , "` + `MIRO_SHARE_ALLOWED_DOMAINS=corp.com` blocks `attacker@corp.com`.

Ref: `claude-code-config` bead `2xy7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
