### PR TITLE
ci: retry Miro spec download on transient failures

### DIFF
--- a/.github/workflows/api-tracking.yml
+++ b/.github/workflows/api-tracking.yml
@@ -18,7 +18,9 @@ jobs:
 
       - name: Download latest Miro OpenAPI spec
         run: |
+          # Retry on transient failures (e.g. raw.githubusercontent.com 429 rate limits)
           curl -fsSL \
+            --retry 5 --retry-delay 10 --retry-all-errors \
             "https://raw.githubusercontent.com/miroapp/api-clients/main/packages/generator/spec.json" \
             -o /tmp/miro-spec-latest.json
 


### PR DESCRIPTION
## Problem

The scheduled **Miro API Tracking** workflow ([run #28792081305](https://github.com/olgasafonova/miro-mcp-server/actions/runs/28792081305)) failed on its first step:

```
curl: (22) The requested URL returned error: 429
```

`raw.githubusercontent.com` rate-limited the OpenAPI spec download. The `curl` had no retry, so a single transient 429 failed the whole scheduled job.

## Fix

Add retry/backoff to the download step:

```
curl -fsSL --retry 5 --retry-delay 10 --retry-all-errors ...
```

`--retry-all-errors` makes curl retry on 429 (and other transient errors) instead of failing immediately.

The failed run has already been re-run manually and passed; this prevents recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)