### PR TITLE
ci: disable golangci-lint remote schema verify to prevent flaky lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,11 @@ jobs:
         with:
           version: v2.7.2
           args: --timeout=5m
+          # Skip `golangci-lint config verify`, which fetches a JSON schema
+          # from golangci-lint.run at runtime and intermittently fails the job
+          # with "context deadline exceeded" when that host is slow/unreachable.
+          # The config is already validated by the lint run itself.
+          verify: false
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
golangci-lint-action@v9 defaults to verify: true, which runs
`golangci-lint config verify` and fetches a JSON schema from
golangci-lint.run at runtime. That network fetch can time out with
"context deadline exceeded", failing CI for reasons unrelated to the
code (as observed in the sister ridge repo). Set verify: false to drop
the network dependency; the config is still validated by the lint run
itself.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01URYBERR7Mf4S7SzQR6tfBC