### PR TITLE
ci: pin artifact/release actions to verified SHAs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
           go build -ldflags="-s -w" -o miro-mcp-server-${{ matrix.suffix }} .
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: miro-mcp-server-${{ matrix.suffix }}
           path: miro-mcp-server-${{ matrix.suffix }}
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts
 


### PR DESCRIPTION
Pins the artifact GitHub Actions used in `.github/workflows/release.yml` to immutable commit SHAs instead of mutable version tags, for supply-chain safety:

- `actions/upload-artifact@v7` → `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` (v7.0.1)
- `actions/download-artifact@v8` → `3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c` (v8.0.1)

The SHAs were verified to exist, and the v7/v8 upload/download pair was confirmed compatible via a real upload→download roundtrip in a sibling repo. No other actions were touched (`actions/checkout`, `actions/setup-go`, etc. are unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018S3jXgMVxkQgPgb4rWZMBT)_