### PR TITLE
quality: raise CodeScene Code Health across the portfolio to 10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Run your [Miro](https://miro.com) workshops, retros, and planning sessions from 
 **98 tools** | **Single binary** | **All platforms** | **All major AI tools**
 
 [![CI](https://github.com/olgasafonova/miro-mcp-server/actions/workflows/ci.yml/badge.svg)](https://github.com/olgasafonova/miro-mcp-server/actions/workflows/ci.yml)
-[![Go Report Card](https://goreportcard.com/badge/github.com/olgasafonova/miro-mcp-server)](https://goreportcard.com/report/github.com/olgasafonova/miro-mcp-server)
+<!-- CodeScene Code Health badge: add after onboarding repo at codescene.io -->
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![MCP Context — full](badges/mcp-tokens.svg)](#token-efficiency)
 [![MCP Context — essentials](badges/mcp-tokens-essentials.svg)](#token-efficiency)

--- a/miro/audit/memory.go
+++ b/miro/audit/memory.go
@@ -157,22 +157,19 @@ func matchesTimeRange(event Event, opts QueryOptions) bool {
 }
 
 // matchesFieldFilters checks the exact-match field filters (tool, method,
-// user, board, action, success).
+// user, board, action, success). An empty filter value matches everything.
 func matchesFieldFilters(event Event, opts QueryOptions) bool {
-	if opts.Tool != "" && event.Tool != opts.Tool {
-		return false
+	filters := []struct{ want, got string }{
+		{opts.Tool, event.Tool},
+		{opts.Method, event.Method},
+		{opts.UserID, event.UserID},
+		{opts.BoardID, event.BoardID},
+		{string(opts.Action), string(event.Action)},
 	}
-	if opts.Method != "" && event.Method != opts.Method {
-		return false
-	}
-	if opts.UserID != "" && event.UserID != opts.UserID {
-		return false
-	}
-	if opts.BoardID != "" && event.BoardID != opts.BoardID {
-		return false
-	}
-	if opts.Action != "" && event.Action != opts.Action {
-		return false
+	for _, f := range filters {
+		if f.want != "" && f.got != f.want {
+			return false
+		}
 	}
 	if opts.Success != nil && event.Success != *opts.Success {
 		return false

--- a/miro/boards.go
+++ b/miro/boards.go
@@ -14,11 +14,20 @@ import (
 // =============================================================================
 
 // ListBoards retrieves boards accessible to the user.
-func (c *Client) ListBoards(ctx context.Context, args ListBoardsArgs) (ListBoardsResult, error) {
-	// Build query parameters
+// clampBoardLimit normalizes a requested page size to the boards endpoint's
+// bounds.
+func clampBoardLimit(limit int) int {
+	if limit > 0 && limit <= MaxBoardLimit {
+		return limit
+	}
+	return DefaultBoardLimit
+}
+
+// buildListBoardsQuery assembles the query parameters for a boards listing.
+// The team ID falls back to the client config when not supplied.
+func (c *Client) buildListBoardsQuery(args ListBoardsArgs, limit int) url.Values {
 	params := url.Values{}
 
-	// Use TeamID from args, or fall back to config's TeamID
 	teamID := args.TeamID
 	if teamID == "" && c.config != nil {
 		teamID = c.config.TeamID
@@ -30,19 +39,37 @@ func (c *Client) ListBoards(ctx context.Context, args ListBoardsArgs) (ListBoard
 	if args.Query != "" {
 		params.Set("query", args.Query)
 	}
-	limit := DefaultBoardLimit
-	if args.Limit > 0 && args.Limit <= MaxBoardLimit {
-		limit = args.Limit
-	}
 	params.Set("limit", strconv.Itoa(limit))
 	if args.Offset != "" {
 		params.Set("offset", args.Offset)
 	}
+	return params
+}
 
-	path := "/boards"
-	if len(params) > 0 {
-		path += "?" + params.Encode()
+// summarizeBoards projects full board objects to list summaries.
+func summarizeBoards(data []Board) []BoardSummary {
+	boards := make([]BoardSummary, len(data))
+	for i, b := range data {
+		boards[i] = BoardSummary{
+			ID:          b.ID,
+			Name:        b.Name,
+			Description: b.Description,
+			ViewLink:    b.ViewLink,
+		}
+		if b.Team != nil {
+			boards[i].TeamName = b.Team.Name
+		}
 	}
+	return boards
+}
+
+func (c *Client) ListBoards(ctx context.Context, args ListBoardsArgs) (ListBoardsResult, error) {
+	limit := clampBoardLimit(args.Limit)
+	params := c.buildListBoardsQuery(args, limit)
+
+	// params always carries at least the limit, so the query string is
+	// unconditionally present.
+	path := "/boards?" + params.Encode()
 
 	respBody, err := c.request(ctx, http.MethodGet, path, nil)
 	if err != nil {
@@ -59,19 +86,7 @@ func (c *Client) ListBoards(ctx context.Context, args ListBoardsArgs) (ListBoard
 		return ListBoardsResult{}, fmt.Errorf("failed to parse response: %w", err)
 	}
 
-	// Convert to summaries
-	boards := make([]BoardSummary, len(resp.Data))
-	for i, b := range resp.Data {
-		boards[i] = BoardSummary{
-			ID:          b.ID,
-			Name:        b.Name,
-			Description: b.Description,
-			ViewLink:    b.ViewLink,
-		}
-		if b.Team != nil {
-			boards[i].TeamName = b.Team.Name
-		}
-	}
+	boards := summarizeBoards(resp.Data)
 
 	// Convert numeric offset to string for external API compatibility
 	offsetStr := ""
@@ -117,24 +132,30 @@ func (c *Client) GetBoard(ctx context.Context, args GetBoardArgs) (GetBoardResul
 	return result, nil
 }
 
+// boardFields collects the optional board attributes (name, description,
+// team) that are shared by the create, copy, and update request bodies.
+// Empty values are omitted.
+func boardFields(name, description, teamID string) map[string]interface{} {
+	reqBody := make(map[string]interface{})
+	if name != "" {
+		reqBody["name"] = name
+	}
+	if description != "" {
+		reqBody["description"] = description
+	}
+	if teamID != "" {
+		reqBody["teamId"] = teamID
+	}
+	return reqBody
+}
+
 // CreateBoard creates a new Miro board.
 func (c *Client) CreateBoard(ctx context.Context, args CreateBoardArgs) (CreateBoardResult, error) {
 	if args.Name == "" {
 		return CreateBoardResult{}, fmt.Errorf("name is required")
 	}
 
-	reqBody := map[string]interface{}{
-		"name": args.Name,
-	}
-
-	if args.Description != "" {
-		reqBody["description"] = args.Description
-	}
-
-	if args.TeamID != "" {
-		reqBody["teamId"] = args.TeamID
-	}
-
+	reqBody := boardFields(args.Name, args.Description, args.TeamID)
 	respBody, err := c.request(ctx, http.MethodPost, "/boards", reqBody)
 	if err != nil {
 		return CreateBoardResult{}, err
@@ -160,17 +181,7 @@ func (c *Client) CopyBoard(ctx context.Context, args CopyBoardArgs) (CopyBoardRe
 		return CopyBoardResult{}, err
 	}
 
-	reqBody := make(map[string]interface{})
-
-	if args.Name != "" {
-		reqBody["name"] = args.Name
-	}
-	if args.Description != "" {
-		reqBody["description"] = args.Description
-	}
-	if args.TeamID != "" {
-		reqBody["teamId"] = args.TeamID
-	}
+	reqBody := boardFields(args.Name, args.Description, args.TeamID)
 
 	// Miro API uses PUT /boards?copy_from={board_id} to copy boards
 	path := "/boards?copy_from=" + url.QueryEscape(args.BoardID)
@@ -235,14 +246,7 @@ func (c *Client) UpdateBoard(ctx context.Context, args UpdateBoardArgs) (UpdateB
 		return UpdateBoardResult{}, fmt.Errorf("at least one of name or description is required")
 	}
 
-	reqBody := make(map[string]interface{})
-	if args.Name != "" {
-		reqBody["name"] = args.Name
-	}
-	if args.Description != "" {
-		reqBody["description"] = args.Description
-	}
-
+	reqBody := boardFields(args.Name, args.Description, "")
 	respBody, err := c.request(ctx, http.MethodPatch, "/boards/"+args.BoardID, reqBody)
 	if err != nil {
 		return UpdateBoardResult{}, err

--- a/miro/boards_summary.go
+++ b/miro/boards_summary.go
@@ -89,7 +89,12 @@ func (c *Client) GetBoardContent(ctx context.Context, args GetBoardContentArgs) 
 		result.Tags = c.loadTagContexts(ctx, args.BoardID)
 	}
 
-	result.Message = buildBoardContentMessage(board.Name, allItems.Count, len(frames), len(result.Connectors), len(result.Tags))
+	result.Message = buildBoardContentMessage(board.Name, boardContentCounts{
+		items:      allItems.Count,
+		frames:     len(frames),
+		connectors: len(result.Connectors),
+		tags:       len(result.Tags),
+	})
 
 	return result, nil
 }
@@ -280,18 +285,26 @@ func (c *Client) loadTagContexts(ctx context.Context, boardID string) []TagConte
 	return out
 }
 
+// boardContentCounts holds the per-kind item counts for the summary line.
+type boardContentCounts struct {
+	items      int
+	frames     int
+	connectors int
+	tags       int
+}
+
 // buildBoardContentMessage formats the human-readable summary line.
 // Frames / connectors / tags are appended only when present.
-func buildBoardContentMessage(boardName string, totalItems, framesCount, connectorsCount, tagsCount int) string {
-	parts := []string{fmt.Sprintf("Board '%s' has %d items", boardName, totalItems)}
-	if framesCount > 0 {
-		parts = append(parts, fmt.Sprintf("%d frames", framesCount))
+func buildBoardContentMessage(boardName string, counts boardContentCounts) string {
+	parts := []string{fmt.Sprintf("Board '%s' has %d items", boardName, counts.items)}
+	if counts.frames > 0 {
+		parts = append(parts, fmt.Sprintf("%d frames", counts.frames))
 	}
-	if connectorsCount > 0 {
-		parts = append(parts, fmt.Sprintf("%d connectors", connectorsCount))
+	if counts.connectors > 0 {
+		parts = append(parts, fmt.Sprintf("%d connectors", counts.connectors))
 	}
-	if tagsCount > 0 {
-		parts = append(parts, fmt.Sprintf("%d tags", tagsCount))
+	if counts.tags > 0 {
+		parts = append(parts, fmt.Sprintf("%d tags", counts.tags))
 	}
 	return strings.Join(parts, ", ")
 }

--- a/miro/bulk.go
+++ b/miro/bulk.go
@@ -333,6 +333,22 @@ func updateBulkItem(ctx context.Context, c *Client, boardID string, item BulkUpd
 	}
 }
 
+// runBulkOp is the shared skeleton for bulk create/update: it applies the
+// operation timeout, runs the per-item action in parallel, and aggregates
+// successes and failures. Callers validate the batch size first.
+func runBulkOp[T any](
+	ctx context.Context,
+	items []T,
+	action func(context.Context, int, T) (string, error),
+	formatErr func(idx int, id string, err error) string,
+) bulkAggregation {
+	ctx, cancel := context.WithTimeout(ctx, BulkOperationTimeout)
+	defer cancel()
+
+	resultSlice := runBulkInParallel(ctx, items, action)
+	return processBulkResults(resultSlice, formatErr)
+}
+
 // BulkCreate creates multiple items in one operation.
 // Items are created in parallel using goroutines, with concurrency
 // controlled by the client's semaphore (MaxConcurrentRequests).
@@ -341,18 +357,14 @@ func (c *Client) BulkCreate(ctx context.Context, args BulkCreateArgs) (BulkCreat
 		return BulkCreateResult{}, err
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, BulkOperationTimeout)
-	defer cancel()
-
-	resultSlice := runBulkInParallel(ctx, args.Items, func(ctx context.Context, _ int, item BulkCreateItem) (string, error) {
-		return createBulkItem(ctx, c, args.BoardID, item)
-	})
-
-	agg := processBulkResults(resultSlice, func(idx int, _ string, err error) string {
-		return fmt.Sprintf("item %d: %v", idx+1, err)
-	})
+	agg := runBulkOp(ctx, args.Items,
+		func(ctx context.Context, _ int, item BulkCreateItem) (string, error) {
+			return createBulkItem(ctx, c, args.BoardID, item)
+		},
+		func(idx int, _ string, err error) string {
+			return fmt.Sprintf("item %d: %v", idx+1, err)
+		})
 	retriableIDs := retriableIndexes(agg.failedItems)
-
 	return BulkCreateResult{
 		Created:      len(agg.successIDs),
 		ItemIDs:      agg.successIDs,
@@ -372,18 +384,14 @@ func (c *Client) BulkUpdate(ctx context.Context, args BulkUpdateArgs) (BulkUpdat
 		return BulkUpdateResult{}, err
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, BulkOperationTimeout)
-	defer cancel()
-
-	resultSlice := runBulkInParallel(ctx, args.Items, func(ctx context.Context, _ int, item BulkUpdateItem) (string, error) {
-		return updateBulkItem(ctx, c, args.BoardID, item)
-	})
-
-	agg := processBulkResults(resultSlice, func(idx int, id string, err error) string {
-		return fmt.Sprintf("item %d (%s): %v", idx+1, id, err)
-	})
+	agg := runBulkOp(ctx, args.Items,
+		func(ctx context.Context, _ int, item BulkUpdateItem) (string, error) {
+			return updateBulkItem(ctx, c, args.BoardID, item)
+		},
+		func(idx int, id string, err error) string {
+			return fmt.Sprintf("item %d (%s): %v", idx+1, id, err)
+		})
 	retriableIDs := retriableItemIDs(agg.failedItems)
-
 	return BulkUpdateResult{
 		Updated:      len(agg.successIDs),
 		ItemIDs:      agg.successIDs,

--- a/miro/codewidgets.go
+++ b/miro/codewidgets.go
@@ -34,10 +34,22 @@ func wrapExperimentalCodeWidgetErr(err error) error {
 		return nil
 	}
 	var apiErr *APIError
-	if errors.As(err, &apiErr) && (apiErr.IsNotFound() || apiErr.IsForbidden()) {
+	if !errors.As(err, &apiErr) {
+		return err
+	}
+	if isExperimentalAccessDenied(apiErr) {
 		return fmt.Errorf("%w (note: code_widgets is a v2-experimental Miro API and may be unavailable for your account or plan)", err)
 	}
 	return err
+}
+
+// isExperimentalAccessDenied reports whether an API error is the ambiguous
+// 403/404 shape that may indicate missing v2-experimental access.
+func isExperimentalAccessDenied(apiErr *APIError) bool {
+	if apiErr.IsNotFound() {
+		return true
+	}
+	return apiErr.IsForbidden()
 }
 
 // validateCodeWidgetData checks the API-documented field caps shared by
@@ -83,27 +95,66 @@ func buildCodeWidgetData(code, language, title string, lineNumbersVisible *bool)
 	return data
 }
 
-// CreateCodeWidget creates a code widget on a board.
-// Uses the v2-experimental API.
-func (c *Client) CreateCodeWidget(ctx context.Context, args CreateCodeWidgetArgs) (CreateCodeWidgetResult, error) {
-	if err := ValidateBoardID(args.BoardID); err != nil {
-		return CreateCodeWidgetResult{}, err
+// validateCodeWidgetWriteArgs checks the ID formats and field caps shared by
+// create and update requests.
+func validateCodeWidgetWriteArgs(boardID, code, title, parentID string) error {
+	if err := ValidateBoardID(boardID); err != nil {
+		return err
+	}
+	if err := validateCodeWidgetData(code, title); err != nil {
+		return err
+	}
+	return validateOptionalParentID(parentID)
+}
+
+// validateCreateCodeWidgetArgs checks required fields and ID formats before
+// a create request is issued.
+func validateCreateCodeWidgetArgs(args CreateCodeWidgetArgs) error {
+	if err := validateCodeWidgetWriteArgs(args.BoardID, args.Code, args.Title, args.ParentID); err != nil {
+		return err
 	}
 	if args.Code == "" {
-		return CreateCodeWidgetResult{}, fmt.Errorf("code is required")
+		return fmt.Errorf("code is required")
 	}
-	if err := validateCodeWidgetData(args.Code, args.Title); err != nil {
-		return CreateCodeWidgetResult{}, err
-	}
-	if args.ParentID != "" {
-		if err := ValidateItemID(args.ParentID); err != nil {
-			return CreateCodeWidgetResult{}, fmt.Errorf("invalid parent_id: %w", err)
-		}
-	}
+	return nil
+}
 
-	reqBody := map[string]interface{}{
-		"data": buildCodeWidgetData(args.Code, args.Language, args.Title, args.LineNumbersVisible),
+// validateOptionalParentID validates a parent item ID when one is supplied.
+func validateOptionalParentID(parentID string) error {
+	if parentID == "" {
+		return nil
 	}
+	if err := ValidateItemID(parentID); err != nil {
+		return fmt.Errorf("invalid parent_id: %w", err)
+	}
+	return nil
+}
+
+// buildCodeWidgetWriteBody assembles the data/geometry/parent fields shared
+// by create and update request bodies.
+func buildCodeWidgetWriteBody(data, geo map[string]interface{}, parentID string) map[string]interface{} {
+	reqBody := map[string]interface{}{}
+	if data != nil {
+		reqBody["data"] = data
+	}
+	if geo != nil {
+		reqBody["geometry"] = geo
+	}
+	if parentID != "" {
+		reqBody["parent"] = map[string]interface{}{"id": parentID}
+	}
+	return reqBody
+}
+
+// buildCreateCodeWidgetBody assembles the request body for a create call.
+// Create runs after validation, so the code field (and thus the data block)
+// is always present.
+func buildCreateCodeWidgetBody(args CreateCodeWidgetArgs) map[string]interface{} {
+	reqBody := buildCodeWidgetWriteBody(
+		buildCodeWidgetData(args.Code, args.Language, args.Title, args.LineNumbersVisible),
+		buildCodeWidgetGeometry(args.Width, args.Height),
+		args.ParentID,
+	)
 	if args.X != 0 || args.Y != 0 {
 		reqBody["position"] = map[string]interface{}{
 			"x":      args.X,
@@ -111,13 +162,26 @@ func (c *Client) CreateCodeWidget(ctx context.Context, args CreateCodeWidgetArgs
 			"origin": "center",
 		}
 	}
-	if geo := buildCodeWidgetGeometry(args.Width, args.Height); geo != nil {
-		reqBody["geometry"] = geo
+	return reqBody
+}
+
+// codeWidgetLabel picks the display label for a created widget: the title
+// when present, otherwise a short excerpt of the code.
+func codeWidgetLabel(title, code string) string {
+	if title != "" {
+		return title
 	}
-	if args.ParentID != "" {
-		reqBody["parent"] = map[string]interface{}{"id": args.ParentID}
+	return truncateCodeWidget(code, 30)
+}
+
+// CreateCodeWidget creates a code widget on a board.
+// Uses the v2-experimental API.
+func (c *Client) CreateCodeWidget(ctx context.Context, args CreateCodeWidgetArgs) (CreateCodeWidgetResult, error) {
+	if err := validateCreateCodeWidgetArgs(args); err != nil {
+		return CreateCodeWidgetResult{}, err
 	}
 
+	reqBody := buildCreateCodeWidgetBody(args)
 	respBody, err := c.requestExperimental(ctx, http.MethodPost, "/boards/"+args.BoardID+"/code_widgets", reqBody)
 	if err != nil {
 		return CreateCodeWidgetResult{}, wrapExperimentalCodeWidgetErr(err)
@@ -136,10 +200,7 @@ func (c *Client) CreateCodeWidget(ctx context.Context, args CreateCodeWidgetArgs
 
 	c.cache.InvalidatePrefix("items:" + args.BoardID)
 
-	label := widget.Data.Title
-	if label == "" {
-		label = truncateCodeWidget(args.Code, 30)
-	}
+	label := codeWidgetLabel(widget.Data.Title, args.Code)
 	return CreateCodeWidgetResult{
 		ID:       widget.ID,
 		ItemURL:  BuildItemURL(args.BoardID, widget.ID),
@@ -231,41 +292,11 @@ func (c *Client) GetCodeWidget(ctx context.Context, args GetCodeWidgetArgs) (Get
 	return result, nil
 }
 
-// ListCodeWidgets retrieves code widgets on a board with cursor pagination.
-// Uses the v2-experimental API.
-func (c *Client) ListCodeWidgets(ctx context.Context, args ListCodeWidgetsArgs) (ListCodeWidgetsResult, error) {
-	if err := ValidateBoardID(args.BoardID); err != nil {
-		return ListCodeWidgetsResult{}, err
-	}
-
-	limit := args.Limit
-	if limit <= 0 {
-		limit = DefaultItemLimit
-	}
-	if limit > MaxItemLimitExtended {
-		limit = MaxItemLimitExtended
-	}
-
-	path := fmt.Sprintf("/boards/%s/code_widgets?limit=%d", args.BoardID, limit)
-	if args.Cursor != "" {
-		path += "&cursor=" + args.Cursor
-	}
-
-	respBody, err := c.requestExperimental(ctx, http.MethodGet, path, nil)
-	if err != nil {
-		return ListCodeWidgetsResult{}, wrapExperimentalCodeWidgetErr(err)
-	}
-
-	var resp struct {
-		Data   []json.RawMessage `json:"data"`
-		Cursor string            `json:"cursor,omitempty"`
-	}
-	if err := json.Unmarshal(respBody, &resp); err != nil {
-		return ListCodeWidgetsResult{}, fmt.Errorf("failed to parse response: %w", err)
-	}
-
-	widgets := make([]CodeWidgetSummary, 0, len(resp.Data))
-	for _, raw := range resp.Data {
+// parseCodeWidgetSummaries converts raw list entries into summaries,
+// skipping entries that fail to parse.
+func parseCodeWidgetSummaries(entries []json.RawMessage) []CodeWidgetSummary {
+	widgets := make([]CodeWidgetSummary, 0, len(entries))
+	for _, raw := range entries {
 		var widget struct {
 			ID   string `json:"id"`
 			Data struct {
@@ -292,6 +323,48 @@ func (c *Client) ListCodeWidgets(ctx context.Context, args ListCodeWidgetsArgs) 
 		}
 		widgets = append(widgets, summary)
 	}
+	return widgets
+}
+
+// clampCodeWidgetLimit normalizes a requested page size to the API bounds.
+func clampCodeWidgetLimit(limit int) int {
+	if limit <= 0 {
+		return DefaultItemLimit
+	}
+	if limit > MaxItemLimitExtended {
+		return MaxItemLimitExtended
+	}
+	return limit
+}
+
+// ListCodeWidgets retrieves code widgets on a board with cursor pagination.
+// Uses the v2-experimental API.
+func (c *Client) ListCodeWidgets(ctx context.Context, args ListCodeWidgetsArgs) (ListCodeWidgetsResult, error) {
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return ListCodeWidgetsResult{}, err
+	}
+
+	limit := clampCodeWidgetLimit(args.Limit)
+
+	path := fmt.Sprintf("/boards/%s/code_widgets?limit=%d", args.BoardID, limit)
+	if args.Cursor != "" {
+		path += "&cursor=" + args.Cursor
+	}
+
+	respBody, err := c.requestExperimental(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return ListCodeWidgetsResult{}, wrapExperimentalCodeWidgetErr(err)
+	}
+
+	var resp struct {
+		Data   []json.RawMessage `json:"data"`
+		Cursor string            `json:"cursor,omitempty"`
+	}
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return ListCodeWidgetsResult{}, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	widgets := parseCodeWidgetSummaries(resp.Data)
 
 	return ListCodeWidgetsResult{
 		Widgets: widgets,
@@ -302,34 +375,33 @@ func (c *Client) ListCodeWidgets(ctx context.Context, args ListCodeWidgetsArgs) 
 	}, nil
 }
 
+// validateUpdateCodeWidgetArgs checks ID formats and field caps before an
+// update request is issued.
+func validateUpdateCodeWidgetArgs(args UpdateCodeWidgetArgs) error {
+	if err := ValidateItemID(args.ItemID); err != nil {
+		return fmt.Errorf("invalid item_id: %w", err)
+	}
+	return validateCodeWidgetWriteArgs(args.BoardID, args.Code, args.Title, args.ParentID)
+}
+
+// buildUpdateCodeWidgetBody assembles the request body for an update call;
+// empty map means no updatable field was supplied.
+func buildUpdateCodeWidgetBody(args UpdateCodeWidgetArgs) map[string]interface{} {
+	return buildCodeWidgetWriteBody(
+		buildCodeWidgetData(args.Code, args.Language, args.Title, args.LineNumbersVisible),
+		buildCodeWidgetGeometry(args.Width, args.Height),
+		args.ParentID,
+	)
+}
+
 // UpdateCodeWidget updates a code widget's content, appearance, or parent.
 // Position moves go through MoveCodeWidget. Uses the v2-experimental API.
 func (c *Client) UpdateCodeWidget(ctx context.Context, args UpdateCodeWidgetArgs) (UpdateCodeWidgetResult, error) {
-	if err := ValidateBoardID(args.BoardID); err != nil {
+	if err := validateUpdateCodeWidgetArgs(args); err != nil {
 		return UpdateCodeWidgetResult{}, err
-	}
-	if err := ValidateItemID(args.ItemID); err != nil {
-		return UpdateCodeWidgetResult{}, fmt.Errorf("invalid item_id: %w", err)
-	}
-	if err := validateCodeWidgetData(args.Code, args.Title); err != nil {
-		return UpdateCodeWidgetResult{}, err
-	}
-	if args.ParentID != "" {
-		if err := ValidateItemID(args.ParentID); err != nil {
-			return UpdateCodeWidgetResult{}, fmt.Errorf("invalid parent_id: %w", err)
-		}
 	}
 
-	reqBody := map[string]interface{}{}
-	if data := buildCodeWidgetData(args.Code, args.Language, args.Title, args.LineNumbersVisible); data != nil {
-		reqBody["data"] = data
-	}
-	if geo := buildCodeWidgetGeometry(args.Width, args.Height); geo != nil {
-		reqBody["geometry"] = geo
-	}
-	if args.ParentID != "" {
-		reqBody["parent"] = map[string]interface{}{"id": args.ParentID}
-	}
+	reqBody := buildUpdateCodeWidgetBody(args)
 	if len(reqBody) == 0 {
 		return UpdateCodeWidgetResult{}, fmt.Errorf("no fields to update; supply at least one of code, language, title, line_numbers_visible, width, height, or parent_id (use miro_move_code_widget to change position)")
 	}

--- a/miro/connectors.go
+++ b/miro/connectors.go
@@ -12,22 +12,43 @@ import (
 // Connector Operations - List, Get, Create, Update, Delete
 // =============================================================================
 
+// clampConnectorLimit normalizes a requested page size to the connector
+// endpoint's bounds (Miro API minimum 10, maximum 100).
+func clampConnectorLimit(limit int) int {
+	if limit <= 0 {
+		limit = 50
+	}
+	if limit < 10 {
+		return 10
+	}
+	if limit > 100 {
+		return 100
+	}
+	return limit
+}
+
+// summarizeConnectors projects full connector objects to list summaries.
+func summarizeConnectors(data []Connector) []ConnectorSummary {
+	connectors := make([]ConnectorSummary, len(data))
+	for i, c := range data {
+		connectors[i] = ConnectorSummary{
+			ID:          c.ID,
+			StartItemID: c.StartItem.ItemID,
+			EndItemID:   c.EndItem.ItemID,
+			Style:       c.Shape,
+			Caption:     extractCaption(c.Captions),
+		}
+	}
+	return connectors
+}
+
 // ListConnectors returns a list of connectors on a board.
 func (c *Client) ListConnectors(ctx context.Context, args ListConnectorsArgs) (ListConnectorsResult, error) {
 	if err := ValidateBoardID(args.BoardID); err != nil {
 		return ListConnectorsResult{}, err
 	}
 
-	limit := args.Limit
-	if limit <= 0 {
-		limit = 50
-	}
-	if limit < 10 {
-		limit = 10 // Miro API minimum for connectors
-	}
-	if limit > 100 {
-		limit = 100
-	}
+	limit := clampConnectorLimit(args.Limit)
 
 	path := fmt.Sprintf("/boards/%s/connectors?limit=%d", args.BoardID, limit)
 	if args.Cursor != "" {
@@ -48,22 +69,12 @@ func (c *Client) ListConnectors(ctx context.Context, args ListConnectorsArgs) (L
 		return ListConnectorsResult{}, fmt.Errorf("failed to parse response: %w", err)
 	}
 
-	connectors := make([]ConnectorSummary, len(resp.Data))
-	for i, c := range resp.Data {
-		connectors[i] = ConnectorSummary{
-			ID:          c.ID,
-			StartItemID: c.StartItem.ItemID,
-			EndItemID:   c.EndItem.ItemID,
-			Style:       c.Shape,
-			Caption:     extractCaption(c.Captions),
-		}
-	}
+	connectors := summarizeConnectors(resp.Data)
 
-	hasMore := resp.Cursor != ""
 	return ListConnectorsResult{
 		Connectors: connectors,
 		Count:      len(connectors),
-		HasMore:    hasMore,
+		HasMore:    resp.Cursor != "",
 		Cursor:     resp.Cursor,
 		Message:    fmt.Sprintf("Found %d connectors", len(connectors)),
 	}, nil
@@ -97,47 +108,39 @@ func (c *Client) GetConnector(ctx context.Context, args GetConnectorArgs) (GetCo
 		return GetConnectorResult{}, fmt.Errorf("failed to parse response: %w", err)
 	}
 
+	return connectorDetails(connector), nil
+}
+
+// connectorDetails projects a full connector object onto the get result,
+// including optional style details and formatted timestamps.
+func connectorDetails(connector Connector) GetConnectorResult {
 	result := GetConnectorResult{
 		ID:          connector.ID,
 		StartItemID: connector.StartItem.ItemID,
 		EndItemID:   connector.EndItem.ItemID,
 		Style:       connector.Shape,
 		Caption:     extractCaption(connector.Captions),
+		StartCap:    connector.Style.StartStrokeCap,
+		EndCap:      connector.Style.EndStrokeCap,
+		Color:       connector.Style.Color,
 		Message:     "Retrieved connector details",
 	}
-
-	// Extract style details if present
-	if connector.Style.StartStrokeCap != "" {
-		result.StartCap = connector.Style.StartStrokeCap
-	}
-	if connector.Style.EndStrokeCap != "" {
-		result.EndCap = connector.Style.EndStrokeCap
-	}
-	if connector.Style.Color != "" {
-		result.Color = connector.Style.Color
-	}
-
-	// Format timestamps
-	if !connector.CreatedAt.IsZero() {
-		result.CreatedAt = connector.CreatedAt.Format(time.RFC3339)
-	}
-	if !connector.ModifiedAt.IsZero() {
-		result.ModifiedAt = connector.ModifiedAt.Format(time.RFC3339)
-	}
-
-	return result, nil
+	result.CreatedAt = formatTimestamp(connector.CreatedAt)
+	result.ModifiedAt = formatTimestamp(connector.ModifiedAt)
+	return result
 }
 
-// CreateConnector creates a connector between two items.
-func (c *Client) CreateConnector(ctx context.Context, args CreateConnectorArgs) (CreateConnectorResult, error) {
-	if err := ValidateBoardID(args.BoardID); err != nil {
-		return CreateConnectorResult{}, err
+// formatTimestamp renders a timestamp as RFC3339, or empty when unset.
+func formatTimestamp(t time.Time) string {
+	if t.IsZero() {
+		return ""
 	}
-	if args.StartItemID == "" || args.EndItemID == "" {
-		return CreateConnectorResult{}, fmt.Errorf("start_item_id and end_item_id are required")
-	}
+	return t.Format(time.RFC3339)
+}
 
-	// Default style
+// buildCreateConnectorBody assembles the request body for a connector
+// create call, applying the default shape and end cap.
+func buildCreateConnectorBody(args CreateConnectorArgs) map[string]interface{} {
 	style := args.Style
 	if style == "" {
 		style = "elbowed"
@@ -162,16 +165,26 @@ func (c *Client) CreateConnector(ctx context.Context, args CreateConnectorArgs) 
 	} else {
 		connectorStyle["endStrokeCap"] = "arrow" // Default arrow at end
 	}
-	if len(connectorStyle) > 0 {
-		reqBody["style"] = connectorStyle
-	}
+	reqBody["style"] = connectorStyle
 
 	if args.Caption != "" {
 		reqBody["captions"] = []map[string]interface{}{
 			{"content": args.Caption},
 		}
 	}
+	return reqBody
+}
 
+// CreateConnector creates a connector between two items.
+func (c *Client) CreateConnector(ctx context.Context, args CreateConnectorArgs) (CreateConnectorResult, error) {
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return CreateConnectorResult{}, err
+	}
+	if args.StartItemID == "" || args.EndItemID == "" {
+		return CreateConnectorResult{}, fmt.Errorf("start_item_id and end_item_id are required")
+	}
+
+	reqBody := buildCreateConnectorBody(args)
 	respBody, err := c.request(ctx, http.MethodPost, "/boards/"+args.BoardID+"/connectors", reqBody)
 	if err != nil {
 		return CreateConnectorResult{}, err
@@ -192,23 +205,32 @@ func (c *Client) CreateConnector(ctx context.Context, args CreateConnectorArgs) 
 	}, nil
 }
 
-// UpdateConnector updates an existing connector.
-func (c *Client) UpdateConnector(ctx context.Context, args UpdateConnectorArgs) (UpdateConnectorResult, error) {
-	if err := ValidateBoardID(args.BoardID); err != nil {
-		return UpdateConnectorResult{}, err
-	}
-	if args.ConnectorID == "" {
-		return UpdateConnectorResult{}, fmt.Errorf("connector_id is required")
-	}
-
+// buildUpdateConnectorBody assembles the request body for a connector
+// update call; an empty map means no updatable field was supplied.
+func buildUpdateConnectorBody(args UpdateConnectorArgs) (map[string]interface{}, error) {
 	reqBody := make(map[string]interface{})
-
-	// Set shape (style) if provided
 	if args.Style != "" {
 		reqBody["shape"] = args.Style
 	}
 
-	// Build style object for caps and color
+	connectorStyle, err := buildConnectorStyle(args)
+	if err != nil {
+		return nil, err
+	}
+	if len(connectorStyle) > 0 {
+		reqBody["style"] = connectorStyle
+	}
+
+	if args.Caption != "" {
+		reqBody["captions"] = []map[string]interface{}{
+			{"content": args.Caption},
+		}
+	}
+	return reqBody, nil
+}
+
+// buildConnectorStyle assembles the caps-and-color style block for an update.
+func buildConnectorStyle(args UpdateConnectorArgs) (map[string]interface{}, error) {
 	connectorStyle := make(map[string]interface{})
 	if args.StartCap != "" {
 		connectorStyle["startStrokeCap"] = args.StartCap
@@ -219,30 +241,33 @@ func (c *Client) UpdateConnector(ctx context.Context, args UpdateConnectorArgs) 
 	if args.Color != "" {
 		strokeColor, err := normalizeColor(args.Color)
 		if err != nil {
-			return UpdateConnectorResult{}, fmt.Errorf("color: %w", err)
+			return nil, fmt.Errorf("color: %w", err)
 		}
 		connectorStyle["strokeColor"] = strokeColor
 	}
-	if len(connectorStyle) > 0 {
-		reqBody["style"] = connectorStyle
+	return connectorStyle, nil
+}
+
+// UpdateConnector updates an existing connector.
+func (c *Client) UpdateConnector(ctx context.Context, args UpdateConnectorArgs) (UpdateConnectorResult, error) {
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return UpdateConnectorResult{}, err
+	}
+	if args.ConnectorID == "" {
+		return UpdateConnectorResult{}, fmt.Errorf("connector_id is required")
 	}
 
-	// Set caption if provided
-	if args.Caption != "" {
-		reqBody["captions"] = []map[string]interface{}{
-			{"content": args.Caption},
-		}
+	reqBody, err := buildUpdateConnectorBody(args)
+	if err != nil {
+		return UpdateConnectorResult{}, err
 	}
-
-	// If nothing to update, return error
 	if len(reqBody) == 0 {
 		return UpdateConnectorResult{}, fmt.Errorf("at least one update field is required")
 	}
 
 	path := fmt.Sprintf("/boards/%s/connectors/%s", args.BoardID, args.ConnectorID)
 
-	_, err := c.request(ctx, http.MethodPatch, path, reqBody)
-	if err != nil {
+	if _, err := c.request(ctx, http.MethodPatch, path, reqBody); err != nil {
 		return UpdateConnectorResult{}, err
 	}
 

--- a/miro/desirepath/logger.go
+++ b/miro/desirepath/logger.go
@@ -71,6 +71,24 @@ type QueryOptions struct {
 	Limit int       // Max events to return (0 = all)
 }
 
+// matchesQuery reports whether an event passes the query filters.
+func matchesQuery(event Event, opts QueryOptions) bool {
+	if opts.Tool != "" && event.Tool != opts.Tool {
+		return false
+	}
+	if opts.Rule != "" && event.Rule != opts.Rule {
+		return false
+	}
+	return opts.Since.IsZero() || !event.Timestamp.Before(opts.Since)
+}
+
+// reverseEvents reverses the slice in place to most-recent-first order.
+func reverseEvents(events []Event) {
+	for i, j := 0, len(events)-1; i < j; i, j = i+1, j-1 {
+		events[i], events[j] = events[j], events[i]
+	}
+}
+
 // Query retrieves events matching the specified criteria.
 func (l *Logger) Query(opts QueryOptions) []Event {
 	l.mu.RLock()
@@ -80,24 +98,12 @@ func (l *Logger) Query(opts QueryOptions) []Event {
 	for i := 0; i < l.count; i++ {
 		idx := (l.writePos - l.count + i + l.maxSize) % l.maxSize
 		event := l.events[idx]
-
-		if opts.Tool != "" && event.Tool != opts.Tool {
-			continue
+		if matchesQuery(event, opts) {
+			matches = append(matches, event)
 		}
-		if opts.Rule != "" && event.Rule != opts.Rule {
-			continue
-		}
-		if !opts.Since.IsZero() && event.Timestamp.Before(opts.Since) {
-			continue
-		}
-
-		matches = append(matches, event)
 	}
 
-	// Reverse to most-recent-first
-	for i, j := 0, len(matches)-1; i < j; i, j = i+1, j-1 {
-		matches[i], matches[j] = matches[j], matches[i]
-	}
+	reverseEvents(matches)
 
 	if opts.Limit > 0 && len(matches) > opts.Limit {
 		matches = matches[:opts.Limit]

--- a/miro/diagrams.go
+++ b/miro/diagrams.go
@@ -55,9 +55,9 @@ func (c *Client) GenerateDiagram(ctx context.Context, args GenerateDiagramArgs) 
 
 	switch result.OutputMode {
 	case "grouped":
-		c.finalizeGroupedDiagram(ctx, args.BoardID, allItemIDs, totalItems, &result)
+		c.finalizeGroupedDiagram(ctx, args.BoardID, allItemIDs, &result)
 	case "framed":
-		c.finalizeFramedDiagram(ctx, args, diagram, totalItems, &result)
+		c.finalizeFramedDiagram(ctx, args, diagram, &result)
 	default:
 		result.Message = buildDiscreteDiagramMessage(len(nodeIDs), len(connectorIDs), len(frameIDs))
 	}
@@ -237,7 +237,8 @@ func normalizeOutputMode(mode string) string {
 
 // finalizeGroupedDiagram bundles all created items into a single Miro group
 // (when at least two items exist).
-func (c *Client) finalizeGroupedDiagram(ctx context.Context, boardID string, allItemIDs []string, totalItems int, result *GenerateDiagramResult) {
+func (c *Client) finalizeGroupedDiagram(ctx context.Context, boardID string, allItemIDs []string, result *GenerateDiagramResult) {
+	totalItems := result.TotalItems
 	if len(allItemIDs) < 2 {
 		result.Message = fmt.Sprintf("Created diagram with %d items (too few items to group)", totalItems)
 		return
@@ -259,7 +260,8 @@ func (c *Client) finalizeGroupedDiagram(ctx context.Context, boardID string, all
 
 // finalizeFramedDiagram wraps the created items in a containing frame sized
 // to the diagram bounds plus padding.
-func (c *Client) finalizeFramedDiagram(ctx context.Context, args GenerateDiagramArgs, diagram *diagrams.Diagram, totalItems int, result *GenerateDiagramResult) {
+func (c *Client) finalizeFramedDiagram(ctx context.Context, args GenerateDiagramArgs, diagram *diagrams.Diagram, result *GenerateDiagramResult) {
+	totalItems := result.TotalItems
 	const padding = 40.0
 	frameWidth := diagram.Width + padding*2
 	frameHeight := diagram.Height + padding*2

--- a/miro/diagrams/types.go
+++ b/miro/diagrams/types.go
@@ -140,9 +140,18 @@ func (d *Diagram) AddSubGraph(sg *SubGraph) {
 	d.SubGraphs[sg.ID] = sg
 }
 
-// GetNodeOrder returns nodes in topological order for layout.
+// GetNodeOrder returns nodes in topological order for layout, using Kahn's
+// algorithm. Nodes on cycles (never reaching zero in-degree) are appended at
+// the end in map order.
 func (d *Diagram) GetNodeOrder() []string {
-	// Build adjacency list
+	incoming, outgoing := d.buildAdjacency()
+	order := kahnSort(incoming, outgoing)
+	return d.appendCycleNodes(order)
+}
+
+// buildAdjacency computes in-degree counts and outgoing adjacency lists for
+// edges whose endpoints both exist in the node set.
+func (d *Diagram) buildAdjacency() (map[string]int, map[string][]string) {
 	incoming := make(map[string]int)
 	outgoing := make(map[string][]string)
 
@@ -161,42 +170,59 @@ func (d *Diagram) GetNodeOrder() []string {
 		incoming[edge.ToID]++
 		outgoing[edge.FromID] = append(outgoing[edge.FromID], edge.ToID)
 	}
+	return incoming, outgoing
+}
 
-	// Kahn's algorithm for topological sort
-	var queue []string
-	for id, count := range incoming {
-		if count == 0 {
-			queue = append(queue, id)
-		}
-	}
+// kahnSort runs Kahn's algorithm over the adjacency data, consuming the
+// incoming map as it goes.
+func kahnSort(incoming map[string]int, outgoing map[string][]string) []string {
+	queue := zeroInDegreeNodes(incoming)
 
 	var order []string
 	for len(queue) > 0 {
 		node := queue[0]
 		queue = queue[1:]
 		order = append(order, node)
+		queue = append(queue, releaseNeighbors(incoming, outgoing[node])...)
+	}
+	return order
+}
 
-		for _, neighbor := range outgoing[node] {
-			incoming[neighbor]--
-			if incoming[neighbor] == 0 {
-				queue = append(queue, neighbor)
-			}
+// zeroInDegreeNodes collects the nodes with no incoming edges.
+func zeroInDegreeNodes(incoming map[string]int) []string {
+	var queue []string
+	for id, count := range incoming {
+		if count == 0 {
+			queue = append(queue, id)
 		}
 	}
+	return queue
+}
 
-	// Add any remaining nodes (cycles)
-	for id := range d.Nodes {
-		found := false
-		for _, ordered := range order {
-			if ordered == id {
-				found = true
-				break
-			}
+// releaseNeighbors decrements each neighbor's in-degree and returns those
+// that reach zero.
+func releaseNeighbors(incoming map[string]int, neighbors []string) []string {
+	var released []string
+	for _, neighbor := range neighbors {
+		incoming[neighbor]--
+		if incoming[neighbor] == 0 {
+			released = append(released, neighbor)
 		}
-		if !found {
+	}
+	return released
+}
+
+// appendCycleNodes appends any node missing from the sorted order (nodes on
+// cycles never reach zero in-degree during Kahn's algorithm).
+func (d *Diagram) appendCycleNodes(order []string) []string {
+	seen := make(map[string]bool, len(order))
+	for _, id := range order {
+		seen[id] = true
+	}
+	for id := range d.Nodes {
+		if !seen[id] {
 			order = append(order, id)
 		}
 	}
-
 	return order
 }

--- a/miro/docs.go
+++ b/miro/docs.go
@@ -195,51 +195,63 @@ func (c *Client) UpdateDocFormat(ctx context.Context, args UpdateDocFormatArgs) 
 		return UpdateDocFormatResult{}, err
 	}
 
-	// Step 3: Delete original
-	_, err = c.request(ctx, http.MethodDelete, fmt.Sprintf("/boards/%s/items/%s", args.BoardID, args.ItemID), nil)
+	// Step 3+4: Delete original and recreate at the same position
+	newID, err := c.recreateDoc(ctx, args, newContent, getResult)
 	if err != nil {
-		return UpdateDocFormatResult{}, fmt.Errorf("failed to delete original doc: %w", err)
+		return UpdateDocFormatResult{}, err
 	}
 
-	// Step 4: Recreate at same position with new content
+	// Invalidate cache
+	c.cache.InvalidatePrefix("items:" + args.BoardID)
+
+	return UpdateDocFormatResult{
+		ID:       newID,
+		OldID:    args.ItemID,
+		Content:  newContent,
+		ItemURL:  BuildItemURL(args.BoardID, newID),
+		Replaced: replaced,
+		Message:  docFormatUpdateMessage(replaced),
+	}, nil
+}
+
+// recreateDoc deletes the original doc item and recreates it at the same
+// position with the new content, returning the new item's ID.
+func (c *Client) recreateDoc(ctx context.Context, args UpdateDocFormatArgs, newContent string, original GetDocFormatResult) (string, error) {
+	_, err := c.request(ctx, http.MethodDelete, fmt.Sprintf("/boards/%s/items/%s", args.BoardID, args.ItemID), nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to delete original doc: %w", err)
+	}
+
 	reqBody := map[string]interface{}{
 		"data": map[string]interface{}{
 			"contentType": "markdown",
 			"content":     newContent,
 		},
 		"position": map[string]interface{}{
-			"x":      getResult.X,
-			"y":      getResult.Y,
+			"x":      original.X,
+			"y":      original.Y,
 			"origin": "center",
 		},
 	}
 
 	respBody, err := c.request(ctx, http.MethodPost, "/boards/"+args.BoardID+"/docs", reqBody)
 	if err != nil {
-		return UpdateDocFormatResult{}, fmt.Errorf("failed to recreate doc with updated content: %w", err)
+		return "", fmt.Errorf("failed to recreate doc with updated content: %w", err)
 	}
 
 	var resp struct {
 		ID string `json:"id"`
 	}
 	if err := json.Unmarshal(respBody, &resp); err != nil {
-		return UpdateDocFormatResult{}, fmt.Errorf("failed to parse response: %w", err)
+		return "", fmt.Errorf("failed to parse response: %w", err)
 	}
+	return resp.ID, nil
+}
 
-	// Invalidate cache
-	c.cache.InvalidatePrefix("items:" + args.BoardID)
-
-	msg := "Updated doc format item"
+// docFormatUpdateMessage describes the outcome of a doc format update.
+func docFormatUpdateMessage(replaced int) string {
 	if replaced > 0 {
-		msg = fmt.Sprintf("Replaced %d occurrence(s) in doc format item", replaced)
+		return fmt.Sprintf("Replaced %d occurrence(s) in doc format item", replaced)
 	}
-
-	return UpdateDocFormatResult{
-		ID:       resp.ID,
-		OldID:    args.ItemID,
-		Content:  newContent,
-		ItemURL:  BuildItemURL(args.BoardID, resp.ID),
-		Replaced: replaced,
-		Message:  msg,
-	}, nil
+	return "Updated doc format item"
 }

--- a/miro/document.go
+++ b/miro/document.go
@@ -11,6 +11,36 @@ import (
 // Document Operations - Create, Get, Update
 // =============================================================================
 
+// buildCreateDocumentBody assembles the POST body for a document create.
+func buildCreateDocumentBody(args CreateDocumentArgs) map[string]interface{} {
+	data := map[string]interface{}{
+		"url": args.URL,
+	}
+	if args.Title != "" {
+		data["title"] = args.Title
+	}
+
+	reqBody := map[string]interface{}{
+		"data": data,
+		"position": map[string]interface{}{
+			"x":      args.X,
+			"y":      args.Y,
+			"origin": "center",
+		},
+	}
+	if args.Width > 0 {
+		reqBody["geometry"] = map[string]interface{}{
+			"width": args.Width,
+		}
+	}
+	if args.ParentID != "" {
+		reqBody["parent"] = map[string]interface{}{
+			"id": args.ParentID,
+		}
+	}
+	return reqBody
+}
+
 // CreateDocument creates a document on a board from a URL.
 func (c *Client) CreateDocument(ctx context.Context, args CreateDocumentArgs) (CreateDocumentResult, error) {
 	if err := ValidateBoardID(args.BoardID); err != nil {
@@ -20,34 +50,7 @@ func (c *Client) CreateDocument(ctx context.Context, args CreateDocumentArgs) (C
 		return CreateDocumentResult{}, fmt.Errorf("url is required")
 	}
 
-	reqBody := map[string]interface{}{
-		"data": map[string]interface{}{
-			"url": args.URL,
-		},
-		"position": map[string]interface{}{
-			"x":      args.X,
-			"y":      args.Y,
-			"origin": "center",
-		},
-	}
-
-	if args.Title != "" {
-		data := reqBody["data"].(map[string]interface{})
-		data["title"] = args.Title
-	}
-
-	if args.Width > 0 {
-		reqBody["geometry"] = map[string]interface{}{
-			"width": args.Width,
-		}
-	}
-
-	if args.ParentID != "" {
-		reqBody["parent"] = map[string]interface{}{
-			"id": args.ParentID,
-		}
-	}
-
+	reqBody := buildCreateDocumentBody(args)
 	respBody, err := c.request(ctx, http.MethodPost, "/boards/"+args.BoardID+"/documents", reqBody)
 	if err != nil {
 		return CreateDocumentResult{}, err
@@ -95,26 +98,37 @@ func (c *Client) GetDocument(ctx context.Context, args GetDocumentArgs) (GetDocu
 		return GetDocumentResult{}, err
 	}
 
-	var resp struct {
-		ID       string `json:"id"`
-		Position *struct {
-			X float64 `json:"x"`
-			Y float64 `json:"y"`
-		} `json:"position"`
-		Geometry *struct {
-			Width  float64 `json:"width"`
-			Height float64 `json:"height"`
-		} `json:"geometry"`
-		Data struct {
-			Title       string `json:"title"`
-			DocumentURL string `json:"documentUrl"`
-		} `json:"data"`
-		ParentID string `json:"parentId"`
-	}
+	var resp documentItemResponse
 	if err := json.Unmarshal(respBody, &resp); err != nil {
 		return GetDocumentResult{}, fmt.Errorf("failed to parse response: %w", err)
 	}
 
+	result := documentDetails(resp)
+	c.cache.Set(cacheKey, result, c.cacheConfig.ItemTTL)
+
+	return result, nil
+}
+
+// documentItemResponse mirrors the API's document item payload.
+type documentItemResponse struct {
+	ID       string `json:"id"`
+	Position *struct {
+		X float64 `json:"x"`
+		Y float64 `json:"y"`
+	} `json:"position"`
+	Geometry *struct {
+		Width  float64 `json:"width"`
+		Height float64 `json:"height"`
+	} `json:"geometry"`
+	Data struct {
+		Title       string `json:"title"`
+		DocumentURL string `json:"documentUrl"`
+	} `json:"data"`
+	ParentID string `json:"parentId"`
+}
+
+// documentDetails projects the API payload onto the get result.
+func documentDetails(resp documentItemResponse) GetDocumentResult {
 	result := GetDocumentResult{
 		ID:          resp.ID,
 		Title:       resp.Data.Title,
@@ -130,10 +144,7 @@ func (c *Client) GetDocument(ctx context.Context, args GetDocumentArgs) (GetDocu
 		result.Width = resp.Geometry.Width
 		result.Height = resp.Geometry.Height
 	}
-
-	c.cache.Set(cacheKey, result, c.cacheConfig.ItemTTL)
-
-	return result, nil
+	return result
 }
 
 // buildUpdateDocumentBody assembles the PATCH body for a document update.

--- a/miro/embed.go
+++ b/miro/embed.go
@@ -11,15 +11,9 @@ import (
 // Embed Operations - Create, Update
 // =============================================================================
 
-// CreateEmbed creates an embedded content item on a board.
-func (c *Client) CreateEmbed(ctx context.Context, args CreateEmbedArgs) (CreateEmbedResult, error) {
-	if err := ValidateBoardID(args.BoardID); err != nil {
-		return CreateEmbedResult{}, err
-	}
-	if args.URL == "" {
-		return CreateEmbedResult{}, fmt.Errorf("url is required")
-	}
-
+// buildCreateEmbedBody assembles the POST body for an embed create,
+// defaulting the mode to inline.
+func buildCreateEmbedBody(args CreateEmbedArgs) map[string]interface{} {
 	mode := args.Mode
 	if mode == "" {
 		mode = "inline"
@@ -37,25 +31,41 @@ func (c *Client) CreateEmbed(ctx context.Context, args CreateEmbedArgs) (CreateE
 		},
 	}
 
-	// For embeds with fixed aspect ratio (like YouTube), only send width
-	// Miro will calculate height automatically. Sending both causes an error.
-	if args.Width > 0 {
-		reqBody["geometry"] = map[string]interface{}{
-			"width": args.Width,
-		}
-	} else if args.Height > 0 {
-		reqBody["geometry"] = map[string]interface{}{
-			"height": args.Height,
-		}
+	if geo := embedCreateGeometry(args); geo != nil {
+		reqBody["geometry"] = geo
 	}
-	// If neither specified, let Miro use defaults
-
 	if args.ParentID != "" {
 		reqBody["parent"] = map[string]interface{}{
 			"id": args.ParentID,
 		}
 	}
+	return reqBody
+}
 
+// embedCreateGeometry picks a single dimension for the geometry block. For
+// embeds with fixed aspect ratio (like YouTube), only one of width/height is
+// sent and Miro calculates the other; sending both causes an error. Nil when
+// neither is specified, letting Miro use defaults.
+func embedCreateGeometry(args CreateEmbedArgs) map[string]interface{} {
+	if args.Width > 0 {
+		return map[string]interface{}{"width": args.Width}
+	}
+	if args.Height > 0 {
+		return map[string]interface{}{"height": args.Height}
+	}
+	return nil
+}
+
+// CreateEmbed creates an embedded content item on a board.
+func (c *Client) CreateEmbed(ctx context.Context, args CreateEmbedArgs) (CreateEmbedResult, error) {
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return CreateEmbedResult{}, err
+	}
+	if args.URL == "" {
+		return CreateEmbedResult{}, fmt.Errorf("url is required")
+	}
+
+	reqBody := buildCreateEmbedBody(args)
 	respBody, err := c.request(ctx, http.MethodPost, "/boards/"+args.BoardID+"/embeds", reqBody)
 	if err != nil {
 		return CreateEmbedResult{}, err

--- a/miro/export.go
+++ b/miro/export.go
@@ -50,38 +50,65 @@ func (c *Client) GetBoardPicture(ctx context.Context, args GetBoardPictureArgs) 
 // Export Jobs (Enterprise Only)
 // =============================================================================
 
+// validateCreateExportJobArgs checks the org ID, board count cap, and each
+// board ID before an export job is created.
+func validateCreateExportJobArgs(args CreateExportJobArgs) error {
+	if err := ValidateOrgID(args.OrgID); err != nil {
+		return fmt.Errorf("%w (Enterprise feature)", err)
+	}
+	if len(args.BoardIDs) == 0 {
+		return fmt.Errorf("board_ids is required (at least one board)")
+	}
+	if len(args.BoardIDs) > 50 {
+		return fmt.Errorf("maximum 50 boards per export job")
+	}
+	return validateExportBoardIDs(args.BoardIDs)
+}
+
+// validateExportBoardIDs validates every board ID in an export request.
+func validateExportBoardIDs(boardIDs []string) error {
+	for i, boardID := range boardIDs {
+		if err := ValidateBoardID(boardID); err != nil {
+			return fmt.Errorf("board_ids[%d]: %w", i, err)
+		}
+	}
+	return nil
+}
+
+// exportRequestID returns the supplied request ID, or generates one.
+func exportRequestID(requestID string) string {
+	if requestID == "" {
+		return uuid.New().String()
+	}
+	return requestID
+}
+
+// resolveExportFormat applies the default export format and rejects
+// unsupported values.
+func resolveExportFormat(format string) (string, error) {
+	switch format {
+	case "":
+		return "pdf", nil
+	case "pdf", "svg", "html":
+		return format, nil
+	default:
+		return "", fmt.Errorf("format must be pdf, svg, or html")
+	}
+}
+
 // CreateExportJob creates an export job for one or more boards.
 // This is an Enterprise-only feature requiring the boards:export scope.
 // Up to 50 boards can be exported in a single job.
 func (c *Client) CreateExportJob(ctx context.Context, args CreateExportJobArgs) (CreateExportJobResult, error) {
-	if err := ValidateOrgID(args.OrgID); err != nil {
-		return CreateExportJobResult{}, fmt.Errorf("%w (Enterprise feature)", err)
-	}
-	if len(args.BoardIDs) == 0 {
-		return CreateExportJobResult{}, fmt.Errorf("board_ids is required (at least one board)")
-	}
-	if len(args.BoardIDs) > 50 {
-		return CreateExportJobResult{}, fmt.Errorf("maximum 50 boards per export job")
-	}
-	for i, boardID := range args.BoardIDs {
-		if err := ValidateBoardID(boardID); err != nil {
-			return CreateExportJobResult{}, fmt.Errorf("board_ids[%d]: %w", i, err)
-		}
+	if err := validateCreateExportJobArgs(args); err != nil {
+		return CreateExportJobResult{}, err
 	}
 
-	// Generate request ID if not provided
-	requestID := args.RequestID
-	if requestID == "" {
-		requestID = uuid.New().String()
-	}
+	requestID := exportRequestID(args.RequestID)
 
-	// Default format
-	format := args.Format
-	if format == "" {
-		format = "pdf"
-	}
-	if format != "pdf" && format != "svg" && format != "html" {
-		return CreateExportJobResult{}, fmt.Errorf("format must be pdf, svg, or html")
+	format, err := resolveExportFormat(args.Format)
+	if err != nil {
+		return CreateExportJobResult{}, err
 	}
 
 	reqBody := map[string]interface{}{

--- a/miro/frames.go
+++ b/miro/frames.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
-	"time"
 )
 
 // =============================================================================
@@ -96,40 +95,27 @@ func (c *Client) GetFrame(ctx context.Context, args GetFrameArgs) (GetFrameResul
 		return GetFrameResult{}, fmt.Errorf("failed to parse response: %w", err)
 	}
 
-	result := GetFrameResult{
-		ID:      frame.ID,
-		Title:   frame.Data.Title,
-		Message: fmt.Sprintf("Retrieved frame '%s'", frame.Data.Title),
-	}
+	return frameDetails(frame), nil
+}
 
-	// Extract position
+// frameDetails projects a full frame object onto the get result.
+func frameDetails(frame Frame) GetFrameResult {
+	result := GetFrameResult{
+		ID:         frame.ID,
+		Title:      frame.Data.Title,
+		Color:      frame.Style.FillColor,
+		ChildCount: len(frame.Children),
+		CreatedAt:  formatTimestamp(frame.CreatedAt),
+		ModifiedAt: formatTimestamp(frame.ModifiedAt),
+		Message:    fmt.Sprintf("Retrieved frame '%s'", frame.Data.Title),
+	}
 	if frame.Position != nil {
 		result.X = frame.Position.X
 		result.Y = frame.Position.Y
 	}
-
-	// Extract geometry
 	if frame.Geometry != nil {
 		result.Width = frame.Geometry.Width
 		result.Height = frame.Geometry.Height
-	}
-
-	// Extract style
-	if frame.Style.FillColor != "" {
-		result.Color = frame.Style.FillColor
-	}
-
-	// Count children if available
-	if len(frame.Children) > 0 {
-		result.ChildCount = len(frame.Children)
-	}
-
-	// Format timestamps
-	if !frame.CreatedAt.IsZero() {
-		result.CreatedAt = frame.CreatedAt.Format(time.RFC3339)
-	}
-	if !frame.ModifiedAt.IsZero() {
-		result.ModifiedAt = frame.ModifiedAt.Format(time.RFC3339)
 	}
 	if frame.CreatedBy != nil {
 		result.CreatedBy = frame.CreatedBy.ID
@@ -137,8 +123,58 @@ func (c *Client) GetFrame(ctx context.Context, args GetFrameArgs) (GetFrameResul
 	if frame.ModifiedBy != nil {
 		result.ModifiedBy = frame.ModifiedBy.ID
 	}
+	return result
+}
 
-	return result, nil
+// buildUpdateFrameBody assembles the request body for a frame update; an
+// empty map means no updatable field was supplied.
+func buildUpdateFrameBody(args UpdateFrameArgs) (map[string]interface{}, error) {
+	reqBody := make(map[string]interface{})
+	if args.Title != nil {
+		reqBody["data"] = map[string]interface{}{
+			"title": *args.Title,
+		}
+	}
+	if position := buildOptionalPointBody(args.X, args.Y); len(position) > 0 {
+		reqBody["position"] = position
+	}
+	if geometry := buildOptionalSizeBody(args.Width, args.Height); len(geometry) > 0 {
+		reqBody["geometry"] = geometry
+	}
+	if args.Color != nil {
+		fillColor, err := normalizeColor(*args.Color)
+		if err != nil {
+			return nil, fmt.Errorf("color: %w", err)
+		}
+		reqBody["style"] = map[string]interface{}{
+			"fillColor": fillColor,
+		}
+	}
+	return reqBody, nil
+}
+
+// buildOptionalPointBody collects the position fields that were supplied.
+func buildOptionalPointBody(x, y *float64) map[string]interface{} {
+	position := make(map[string]interface{})
+	if x != nil {
+		position["x"] = *x
+	}
+	if y != nil {
+		position["y"] = *y
+	}
+	return position
+}
+
+// buildOptionalSizeBody collects the geometry fields that were supplied.
+func buildOptionalSizeBody(width, height *float64) map[string]interface{} {
+	geometry := make(map[string]interface{})
+	if width != nil {
+		geometry["width"] = *width
+	}
+	if height != nil {
+		geometry["height"] = *height
+	}
+	return geometry
 }
 
 // UpdateFrame updates an existing frame.
@@ -150,58 +186,16 @@ func (c *Client) UpdateFrame(ctx context.Context, args UpdateFrameArgs) (UpdateF
 		return UpdateFrameResult{}, fmt.Errorf("frame_id is required")
 	}
 
-	reqBody := make(map[string]interface{})
-
-	// Build data object for title
-	if args.Title != nil {
-		reqBody["data"] = map[string]interface{}{
-			"title": *args.Title,
-		}
+	reqBody, err := buildUpdateFrameBody(args)
+	if err != nil {
+		return UpdateFrameResult{}, err
 	}
-
-	// Build position object
-	position := make(map[string]interface{})
-	if args.X != nil {
-		position["x"] = *args.X
-	}
-	if args.Y != nil {
-		position["y"] = *args.Y
-	}
-	if len(position) > 0 {
-		reqBody["position"] = position
-	}
-
-	// Build geometry object
-	geometry := make(map[string]interface{})
-	if args.Width != nil {
-		geometry["width"] = *args.Width
-	}
-	if args.Height != nil {
-		geometry["height"] = *args.Height
-	}
-	if len(geometry) > 0 {
-		reqBody["geometry"] = geometry
-	}
-
-	// Build style object
-	if args.Color != nil {
-		fillColor, err := normalizeColor(*args.Color)
-		if err != nil {
-			return UpdateFrameResult{}, fmt.Errorf("color: %w", err)
-		}
-		reqBody["style"] = map[string]interface{}{
-			"fillColor": fillColor,
-		}
-	}
-
-	// If nothing to update, return error
 	if len(reqBody) == 0 {
 		return UpdateFrameResult{}, fmt.Errorf("at least one update field is required")
 	}
 
 	path := fmt.Sprintf("/boards/%s/frames/%s", args.BoardID, args.FrameID)
-	_, err := c.request(ctx, http.MethodPatch, path, reqBody)
-	if err != nil {
+	if _, err := c.request(ctx, http.MethodPatch, path, reqBody); err != nil {
 		return UpdateFrameResult{}, err
 	}
 
@@ -263,13 +257,7 @@ func (c *Client) GetFrameItems(ctx context.Context, args GetFrameItemsArgs) (Get
 		return GetFrameItemsResult{}, fmt.Errorf("frame_id is required")
 	}
 
-	limit := args.Limit
-	if limit <= 0 {
-		limit = 50
-	}
-	if limit > 100 {
-		limit = 100
-	}
+	limit := clampFrameItemsLimit(args.Limit)
 
 	// Use the items endpoint with parent_item_id filter to get items within a frame.
 	// The /frames/{id}/items path does not exist in Miro API v2 and returns 404.
@@ -295,24 +283,38 @@ func (c *Client) GetFrameItems(ctx context.Context, args GetFrameItemsArgs) (Get
 		return GetFrameItemsResult{}, fmt.Errorf("failed to parse response: %w", err)
 	}
 
-	// Check if full details are requested
-	fullDetails := strings.EqualFold(args.DetailLevel, "full")
+	items := parseFrameItems(resp.Data, strings.EqualFold(args.DetailLevel, "full"))
 
-	// Parse items into summaries using shared helper
-	items := make([]ItemSummary, 0, len(resp.Data))
-	for _, raw := range resp.Data {
+	return GetFrameItemsResult{
+		Items:   items,
+		Count:   len(items),
+		HasMore: resp.Cursor != "",
+		Cursor:  resp.Cursor,
+		Message: fmt.Sprintf("Found %d items in frame", len(items)),
+	}, nil
+}
+
+// clampFrameItemsLimit normalizes a requested page size to the items
+// endpoint's bounds.
+func clampFrameItemsLimit(limit int) int {
+	if limit <= 0 {
+		return 50
+	}
+	if limit > 100 {
+		return 100
+	}
+	return limit
+}
+
+// parseFrameItems converts raw item entries into summaries using the shared
+// helper, skipping entries that fail to parse.
+func parseFrameItems(entries []json.RawMessage, fullDetails bool) []ItemSummary {
+	items := make([]ItemSummary, 0, len(entries))
+	for _, raw := range entries {
 		item := parseItemSummary(raw, fullDetails)
 		if item.ID != "" {
 			items = append(items, item)
 		}
 	}
-
-	hasMore := resp.Cursor != ""
-	return GetFrameItemsResult{
-		Items:   items,
-		Count:   len(items),
-		HasMore: hasMore,
-		Cursor:  resp.Cursor,
-		Message: fmt.Sprintf("Found %d items in frame", len(items)),
-	}, nil
+	return items
 }

--- a/miro/groups.go
+++ b/miro/groups.go
@@ -11,6 +11,15 @@ import (
 // Group Operations
 // =============================================================================
 
+// groupItemsBody builds the request body shared by group create and update.
+func groupItemsBody(itemIDs []string) map[string]interface{} {
+	return map[string]interface{}{
+		"data": map[string]interface{}{
+			"items": itemIDs,
+		},
+	}
+}
+
 // CreateGroup groups multiple items together on a board.
 func (c *Client) CreateGroup(ctx context.Context, args CreateGroupArgs) (CreateGroupResult, error) {
 	if err := ValidateBoardID(args.BoardID); err != nil {
@@ -20,13 +29,7 @@ func (c *Client) CreateGroup(ctx context.Context, args CreateGroupArgs) (CreateG
 		return CreateGroupResult{}, fmt.Errorf("at least %d items are required to create a group", MinGroupItems)
 	}
 
-	reqBody := map[string]interface{}{
-		"data": map[string]interface{}{
-			"items": args.ItemIDs,
-		},
-	}
-
-	respBody, err := c.request(ctx, http.MethodPost, "/boards/"+args.BoardID+"/groups", reqBody)
+	respBody, err := c.request(ctx, http.MethodPost, "/boards/"+args.BoardID+"/groups", groupItemsBody(args.ItemIDs))
 	if err != nil {
 		return CreateGroupResult{}, err
 	}
@@ -51,10 +54,7 @@ func (c *Client) ListGroups(ctx context.Context, args ListGroupsArgs) (ListGroup
 		return ListGroupsResult{}, err
 	}
 
-	limit := DefaultItemLimit
-	if args.Limit > 0 && args.Limit <= MaxItemLimitExtended {
-		limit = args.Limit
-	}
+	limit := clampGroupItemsLimit(args.Limit)
 
 	path := fmt.Sprintf("/boards/%s/groups?limit=%d", args.BoardID, limit)
 	if args.Cursor != "" {
@@ -83,13 +83,22 @@ func (c *Client) ListGroups(ctx context.Context, args ListGroupsArgs) (ListGroup
 	}, nil
 }
 
+// validateGroupRef validates the (board, group) identifier pair shared by
+// the group read/update/delete operations.
+func validateGroupRef(boardID, groupID string) error {
+	if err := ValidateBoardID(boardID); err != nil {
+		return err
+	}
+	if err := ValidateItemID(groupID); err != nil {
+		return fmt.Errorf("invalid group_id: %w", err)
+	}
+	return nil
+}
+
 // GetGroup retrieves a specific group by ID.
 func (c *Client) GetGroup(ctx context.Context, args GetGroupArgs) (GetGroupResult, error) {
-	if err := ValidateBoardID(args.BoardID); err != nil {
+	if err := validateGroupRef(args.BoardID, args.GroupID); err != nil {
 		return GetGroupResult{}, err
-	}
-	if err := ValidateItemID(args.GroupID); err != nil {
-		return GetGroupResult{}, fmt.Errorf("invalid group_id: %w", err)
 	}
 
 	path := "/boards/" + args.BoardID + "/groups/" + args.GroupID
@@ -113,17 +122,11 @@ func (c *Client) GetGroup(ctx context.Context, args GetGroupArgs) (GetGroupResul
 
 // GetGroupItems retrieves the items in a group.
 func (c *Client) GetGroupItems(ctx context.Context, args GetGroupItemsArgs) (GetGroupItemsResult, error) {
-	if err := ValidateBoardID(args.BoardID); err != nil {
+	if err := validateGroupRef(args.BoardID, args.GroupID); err != nil {
 		return GetGroupItemsResult{}, err
 	}
-	if err := ValidateItemID(args.GroupID); err != nil {
-		return GetGroupItemsResult{}, fmt.Errorf("invalid group_id: %w", err)
-	}
 
-	limit := DefaultItemLimit
-	if args.Limit > 0 && args.Limit <= MaxItemLimitExtended {
-		limit = args.Limit
-	}
+	limit := clampGroupItemsLimit(args.Limit)
 
 	path := fmt.Sprintf("/boards/%s/groups/%s/items?limit=%d", args.BoardID, args.GroupID, limit)
 	if args.Cursor != "" {
@@ -143,9 +146,30 @@ func (c *Client) GetGroupItems(ctx context.Context, args GetGroupItemsArgs) (Get
 		return GetGroupItemsResult{}, fmt.Errorf("failed to parse response: %w", err)
 	}
 
-	// Convert to summaries
-	items := make([]ItemSummary, 0, len(resp.Data))
-	for _, raw := range resp.Data {
+	items := parseGroupItemSummaries(resp.Data)
+
+	return GetGroupItemsResult{
+		Items:   items,
+		Count:   len(items),
+		HasMore: resp.Cursor != "",
+		Message: fmt.Sprintf("Found %d items in group", len(items)),
+	}, nil
+}
+
+// clampGroupItemsLimit normalizes a requested page size; out-of-range values
+// (including values above the extended maximum) fall back to the default.
+func clampGroupItemsLimit(limit int) int {
+	if limit > 0 && limit <= MaxItemLimitExtended {
+		return limit
+	}
+	return DefaultItemLimit
+}
+
+// parseGroupItemSummaries converts raw group item entries into summaries,
+// skipping entries that fail to parse.
+func parseGroupItemSummaries(entries []json.RawMessage) []ItemSummary {
+	items := make([]ItemSummary, 0, len(entries))
+	for _, raw := range entries {
 		var item struct {
 			ID   string `json:"id"`
 			Type string `json:"type"`
@@ -162,36 +186,21 @@ func (c *Client) GetGroupItems(ctx context.Context, args GetGroupItemsArgs) (Get
 			Content: item.Data.Content,
 		})
 	}
-
-	return GetGroupItemsResult{
-		Items:   items,
-		Count:   len(items),
-		HasMore: resp.Cursor != "",
-		Message: fmt.Sprintf("Found %d items in group", len(items)),
-	}, nil
+	return items
 }
 
 // UpdateGroup updates a group's items.
 func (c *Client) UpdateGroup(ctx context.Context, args UpdateGroupArgs) (UpdateGroupResult, error) {
-	if err := ValidateBoardID(args.BoardID); err != nil {
+	if err := validateGroupRef(args.BoardID, args.GroupID); err != nil {
 		return UpdateGroupResult{}, err
-	}
-	if err := ValidateItemID(args.GroupID); err != nil {
-		return UpdateGroupResult{}, fmt.Errorf("invalid group_id: %w", err)
 	}
 	if len(args.ItemIDs) < MinGroupItems {
 		return UpdateGroupResult{}, fmt.Errorf("at least %d items are required in a group", MinGroupItems)
 	}
 
-	reqBody := map[string]interface{}{
-		"data": map[string]interface{}{
-			"items": args.ItemIDs,
-		},
-	}
-
 	path := "/boards/" + args.BoardID + "/groups/" + args.GroupID
 
-	respBody, err := c.request(ctx, http.MethodPut, path, reqBody)
+	respBody, err := c.request(ctx, http.MethodPut, path, groupItemsBody(args.ItemIDs))
 	if err != nil {
 		return UpdateGroupResult{}, err
 	}
@@ -210,23 +219,16 @@ func (c *Client) UpdateGroup(ctx context.Context, args UpdateGroupArgs) (UpdateG
 
 // DeleteGroup deletes a group (items can optionally be deleted too).
 func (c *Client) DeleteGroup(ctx context.Context, args DeleteGroupArgs) (DeleteGroupResult, error) {
-	if err := ValidateBoardID(args.BoardID); err != nil {
+	if err := validateGroupRef(args.BoardID, args.GroupID); err != nil {
 		return DeleteGroupResult{}, err
-	}
-	if err := ValidateItemID(args.GroupID); err != nil {
-		return DeleteGroupResult{}, fmt.Errorf("invalid group_id: %w", err)
 	}
 
 	// Dry-run mode: return preview without deleting
 	if args.DryRun {
-		msg := "[DRY RUN] Would delete group " + args.GroupID + ", items would be ungrouped"
-		if args.DeleteItems {
-			msg = "[DRY RUN] Would delete group " + args.GroupID + " and its items"
-		}
 		return DeleteGroupResult{
 			Success: true,
 			GroupID: args.GroupID,
-			Message: msg,
+			Message: deleteGroupDryRunMessage(args),
 		}, nil
 	}
 
@@ -244,14 +246,25 @@ func (c *Client) DeleteGroup(ctx context.Context, args DeleteGroupArgs) (DeleteG
 		}, err
 	}
 
-	msg := "Group deleted, items ungrouped"
-	if args.DeleteItems {
-		msg = "Group and its items deleted"
-	}
-
 	return DeleteGroupResult{
 		Success: true,
 		GroupID: args.GroupID,
-		Message: msg,
+		Message: deleteGroupDoneMessage(args),
 	}, nil
+}
+
+// deleteGroupDryRunMessage previews what a group delete would do.
+func deleteGroupDryRunMessage(args DeleteGroupArgs) string {
+	if args.DeleteItems {
+		return "[DRY RUN] Would delete group " + args.GroupID + " and its items"
+	}
+	return "[DRY RUN] Would delete group " + args.GroupID + ", items would be ungrouped"
+}
+
+// deleteGroupDoneMessage describes a completed group delete.
+func deleteGroupDoneMessage(args DeleteGroupArgs) string {
+	if args.DeleteItems {
+		return "Group and its items deleted"
+	}
+	return "Group deleted, items ungrouped"
 }

--- a/miro/image.go
+++ b/miro/image.go
@@ -11,6 +11,36 @@ import (
 // Image Operations - Create, Get, Update
 // =============================================================================
 
+// buildCreateImageBody assembles the POST body for an image create.
+func buildCreateImageBody(args CreateImageArgs) map[string]interface{} {
+	data := map[string]interface{}{
+		"url": args.URL,
+	}
+	if args.Title != "" {
+		data["title"] = args.Title
+	}
+
+	reqBody := map[string]interface{}{
+		"data": data,
+		"position": map[string]interface{}{
+			"x":      args.X,
+			"y":      args.Y,
+			"origin": "center",
+		},
+	}
+	if args.Width > 0 {
+		reqBody["geometry"] = map[string]interface{}{
+			"width": args.Width,
+		}
+	}
+	if args.ParentID != "" {
+		reqBody["parent"] = map[string]interface{}{
+			"id": args.ParentID,
+		}
+	}
+	return reqBody
+}
+
 // CreateImage creates an image on a board from a URL.
 func (c *Client) CreateImage(ctx context.Context, args CreateImageArgs) (CreateImageResult, error) {
 	if err := ValidateBoardID(args.BoardID); err != nil {
@@ -20,34 +50,7 @@ func (c *Client) CreateImage(ctx context.Context, args CreateImageArgs) (CreateI
 		return CreateImageResult{}, fmt.Errorf("url is required")
 	}
 
-	reqBody := map[string]interface{}{
-		"data": map[string]interface{}{
-			"url": args.URL,
-		},
-		"position": map[string]interface{}{
-			"x":      args.X,
-			"y":      args.Y,
-			"origin": "center",
-		},
-	}
-
-	if args.Title != "" {
-		data := reqBody["data"].(map[string]interface{})
-		data["title"] = args.Title
-	}
-
-	if args.Width > 0 {
-		reqBody["geometry"] = map[string]interface{}{
-			"width": args.Width,
-		}
-	}
-
-	if args.ParentID != "" {
-		reqBody["parent"] = map[string]interface{}{
-			"id": args.ParentID,
-		}
-	}
-
+	reqBody := buildCreateImageBody(args)
 	respBody, err := c.request(ctx, http.MethodPost, "/boards/"+args.BoardID+"/images", reqBody)
 	if err != nil {
 		return CreateImageResult{}, err
@@ -96,26 +99,37 @@ func (c *Client) GetImage(ctx context.Context, args GetImageArgs) (GetImageResul
 		return GetImageResult{}, err
 	}
 
-	var resp struct {
-		ID       string `json:"id"`
-		Position *struct {
-			X float64 `json:"x"`
-			Y float64 `json:"y"`
-		} `json:"position"`
-		Geometry *struct {
-			Width  float64 `json:"width"`
-			Height float64 `json:"height"`
-		} `json:"geometry"`
-		Data struct {
-			Title    string `json:"title"`
-			ImageURL string `json:"imageUrl"`
-		} `json:"data"`
-		ParentID string `json:"parentId"`
-	}
+	var resp imageItemResponse
 	if err := json.Unmarshal(respBody, &resp); err != nil {
 		return GetImageResult{}, fmt.Errorf("failed to parse response: %w", err)
 	}
 
+	result := imageDetails(resp)
+	c.cache.Set(cacheKey, result, c.cacheConfig.ItemTTL)
+
+	return result, nil
+}
+
+// imageItemResponse mirrors the API's image item payload.
+type imageItemResponse struct {
+	ID       string `json:"id"`
+	Position *struct {
+		X float64 `json:"x"`
+		Y float64 `json:"y"`
+	} `json:"position"`
+	Geometry *struct {
+		Width  float64 `json:"width"`
+		Height float64 `json:"height"`
+	} `json:"geometry"`
+	Data struct {
+		Title    string `json:"title"`
+		ImageURL string `json:"imageUrl"`
+	} `json:"data"`
+	ParentID string `json:"parentId"`
+}
+
+// imageDetails projects the API payload onto the get result.
+func imageDetails(resp imageItemResponse) GetImageResult {
 	result := GetImageResult{
 		ID:       resp.ID,
 		Title:    resp.Data.Title,
@@ -131,10 +145,7 @@ func (c *Client) GetImage(ctx context.Context, args GetImageArgs) (GetImageResul
 		result.Width = resp.Geometry.Width
 		result.Height = resp.Geometry.Height
 	}
-
-	c.cache.Set(cacheKey, result, c.cacheConfig.ItemTTL)
-
-	return result, nil
+	return result
 }
 
 // buildUpdateImageBody assembles the PATCH body for an image update.

--- a/miro/members.go
+++ b/miro/members.go
@@ -20,10 +20,7 @@ func (c *Client) ListBoardMembers(ctx context.Context, args ListBoardMembersArgs
 	}
 
 	params := url.Values{}
-	limit := DefaultItemLimit
-	if args.Limit > 0 && args.Limit <= MaxItemLimitExtended {
-		limit = args.Limit
-	}
+	limit := clampGroupItemsLimit(args.Limit)
 	params.Set("limit", strconv.Itoa(limit))
 	if args.Offset != "" {
 		params.Set("offset", args.Offset)
@@ -45,17 +42,21 @@ func (c *Client) ListBoardMembers(ctx context.Context, args ListBoardMembersArgs
 		return ListBoardMembersResult{}, fmt.Errorf("failed to parse response: %w", err)
 	}
 
-	message := fmt.Sprintf("Found %d board members", len(resp.Data))
-	if len(resp.Data) == 0 {
-		message = "No members found on this board"
-	}
-
 	return ListBoardMembersResult{
 		Members: resp.Data,
 		Count:   len(resp.Data),
 		HasMore: resp.Offset > 0 && len(resp.Data) >= limit,
-		Message: message,
+		Message: boardMembersMessage(len(resp.Data)),
 	}, nil
+}
+
+// boardMembersMessage describes a member listing, with an explicit
+// zero-result message.
+func boardMembersMessage(count int) string {
+	if count == 0 {
+		return "No members found on this board"
+	}
+	return fmt.Sprintf("Found %d board members", count)
 }
 
 // ShareBoard shares a board with a user by email.

--- a/miro/metrics.go
+++ b/miro/metrics.go
@@ -198,41 +198,69 @@ func (m *MetricsCollector) PrometheusHandler() http.HandlerFunc {
 		w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
 
 		// Write metrics in Prometheus format
-		writeMetric(w, "miro_mcp_requests_total", "Total number of API requests", "counter", float64(metrics.TotalRequests))
-		writeMetric(w, "miro_mcp_errors_total", "Total number of errors", "counter", float64(metrics.TotalErrors))
-		writeMetric(w, "miro_mcp_rate_limit_hits_total", "Total rate limit encounters", "counter", float64(metrics.RateLimitHits))
-		writeMetric(w, "miro_mcp_retries_total", "Total retry attempts", "counter", float64(metrics.RetryCount))
+		writeCounter(w, "miro_mcp_requests_total", "Total number of API requests", float64(metrics.TotalRequests))
+		writeCounter(w, "miro_mcp_errors_total", "Total number of errors", float64(metrics.TotalErrors))
+		writeCounter(w, "miro_mcp_rate_limit_hits_total", "Total rate limit encounters", float64(metrics.RateLimitHits))
+		writeCounter(w, "miro_mcp_retries_total", "Total retry attempts", float64(metrics.RetryCount))
 
 		// Request latency percentiles
-		writeMetric(w, "miro_mcp_request_duration_p50_milliseconds", "50th percentile request duration", "gauge", float64(metrics.LatencyP50Ms))
-		writeMetric(w, "miro_mcp_request_duration_p95_milliseconds", "95th percentile request duration", "gauge", float64(metrics.LatencyP95Ms))
-		writeMetric(w, "miro_mcp_request_duration_p99_milliseconds", "99th percentile request duration", "gauge", float64(metrics.LatencyP99Ms))
+		writeGauge(w, "miro_mcp_request_duration_p50_milliseconds", "50th percentile request duration", float64(metrics.LatencyP50Ms))
+		writeGauge(w, "miro_mcp_request_duration_p95_milliseconds", "95th percentile request duration", float64(metrics.LatencyP95Ms))
+		writeGauge(w, "miro_mcp_request_duration_p99_milliseconds", "99th percentile request duration", float64(metrics.LatencyP99Ms))
 
 		// Uptime
-		writeMetric(w, "miro_mcp_uptime_seconds", "Server uptime in seconds", "gauge", float64(metrics.UptimeSeconds))
+		writeGauge(w, "miro_mcp_uptime_seconds", "Server uptime in seconds", float64(metrics.UptimeSeconds))
 
 		// Per-method request counts
 		for method, count := range metrics.RequestsByMethod {
-			writeMetricWithLabel(w, "miro_mcp_requests_by_method", "Requests by HTTP method", "counter", "method", method, float64(count))
+			promMetric{
+				name: "miro_mcp_requests_by_method", help: "Requests by HTTP method",
+				metricType: "counter", labelKey: "method", labelValue: method,
+				value: float64(count),
+			}.write(w)
 		}
 
 		// Per-type error counts
 		for errType, count := range metrics.ErrorsByType {
-			writeMetricWithLabel(w, "miro_mcp_errors_by_type", "Errors by type", "counter", "type", errType, float64(count))
+			promMetric{
+				name: "miro_mcp_errors_by_type", help: "Errors by type",
+				metricType: "counter", labelKey: "type", labelValue: errType,
+				value: float64(count),
+			}.write(w)
 		}
 	}
 }
 
-func writeMetric(w http.ResponseWriter, name, help, metricType string, value float64) {
-	w.Write([]byte("# HELP " + name + " " + help + "\n"))
-	w.Write([]byte("# TYPE " + name + " " + metricType + "\n"))
-	w.Write([]byte(name + " " + strconv.FormatFloat(value, 'f', -1, 64) + "\n\n"))
+// promMetric is a single Prometheus-format metric line: name, help text,
+// metric type, an optional label pair, and the value.
+type promMetric struct {
+	name       string
+	help       string
+	metricType string
+	labelKey   string
+	labelValue string
+	value      float64
 }
 
-func writeMetricWithLabel(w http.ResponseWriter, name, help, metricType, labelKey, labelValue string, value float64) {
-	w.Write([]byte("# HELP " + name + " " + help + "\n"))
-	w.Write([]byte("# TYPE " + name + " " + metricType + "\n"))
-	w.Write([]byte(name + "{" + labelKey + "=\"" + labelValue + "\"} " + strconv.FormatFloat(value, 'f', -1, 64) + "\n\n"))
+// write renders the metric's HELP/TYPE header and sample line.
+func (p promMetric) write(w http.ResponseWriter) {
+	series := p.name
+	if p.labelKey != "" {
+		series += "{" + p.labelKey + "=\"" + p.labelValue + "\"}"
+	}
+	w.Write([]byte("# HELP " + p.name + " " + p.help + "\n"))
+	w.Write([]byte("# TYPE " + p.name + " " + p.metricType + "\n"))
+	w.Write([]byte(series + " " + strconv.FormatFloat(p.value, 'f', -1, 64) + "\n\n"))
+}
+
+// writeCounter renders an unlabeled counter metric.
+func writeCounter(w http.ResponseWriter, name, help string, value float64) {
+	promMetric{name: name, help: help, metricType: "counter", value: value}.write(w)
+}
+
+// writeGauge renders an unlabeled gauge metric.
+func writeGauge(w http.ResponseWriter, name, help string, value float64) {
+	promMetric{name: name, help: help, metricType: "gauge", value: value}.write(w)
 }
 
 // calculatePercentiles calculates p50, p95, p99 from a slice of durations

--- a/miro/mindmaps.go
+++ b/miro/mindmaps.go
@@ -21,26 +21,25 @@ func shouldSendMindmapPosition(args CreateMindmapNodeArgs) bool {
 	return args.X != 0 || args.Y != 0
 }
 
-// CreateMindmapNode creates a mindmap node on a board.
-func (c *Client) CreateMindmapNode(ctx context.Context, args CreateMindmapNodeArgs) (CreateMindmapNodeResult, error) {
+// validateCreateMindmapNodeArgs checks the board ID and required content.
+func validateCreateMindmapNodeArgs(args CreateMindmapNodeArgs) error {
 	if err := ValidateBoardID(args.BoardID); err != nil {
-		return CreateMindmapNodeResult{}, err
+		return err
 	}
 	if args.Content == "" {
-		return CreateMindmapNodeResult{}, fmt.Errorf("content is required")
+		return fmt.Errorf("content is required")
 	}
-	if err := ValidateContent(args.Content); err != nil {
-		return CreateMindmapNodeResult{}, err
-	}
+	return ValidateContent(args.Content)
+}
 
-	// Build request body with correct nested structure
-	// Miro v2-experimental mindmap API uses: data.nodeView.data.content
-	nodeViewData := map[string]interface{}{
-		"content": args.Content,
-	}
-
+// buildCreateMindmapNodeBody assembles the request body with the nested
+// structure the v2-experimental mindmap API expects
+// (data.nodeView.data.content).
+func buildCreateMindmapNodeBody(args CreateMindmapNodeArgs) map[string]interface{} {
 	nodeView := map[string]interface{}{
-		"data": nodeViewData,
+		"data": map[string]interface{}{
+			"content": args.Content,
+		},
 	}
 
 	// Set node view type (text or bubble)
@@ -72,7 +71,16 @@ func (c *Client) CreateMindmapNode(ctx context.Context, args CreateMindmapNodeAr
 			"origin": "center",
 		}
 	}
+	return reqBody
+}
 
+// CreateMindmapNode creates a mindmap node on a board.
+func (c *Client) CreateMindmapNode(ctx context.Context, args CreateMindmapNodeArgs) (CreateMindmapNodeResult, error) {
+	if err := validateCreateMindmapNodeArgs(args); err != nil {
+		return CreateMindmapNodeResult{}, err
+	}
+
+	reqBody := buildCreateMindmapNodeBody(args)
 	respBody, err := c.requestExperimental(ctx, http.MethodPost, "/boards/"+args.BoardID+"/mindmap_nodes", reqBody)
 	if err != nil {
 		return CreateMindmapNodeResult{}, err
@@ -140,42 +148,51 @@ func (c *Client) GetMindmapNode(ctx context.Context, args GetMindmapNodeArgs) (G
 		return GetMindmapNodeResult{}, err
 	}
 
-	var node struct {
-		ID       string `json:"id"`
-		Position *struct {
-			X float64 `json:"x"`
-			Y float64 `json:"y"`
-		} `json:"position"`
-		Data struct {
-			IsRoot   bool `json:"isRoot"`
-			NodeView struct {
-				Type string `json:"type"`
-				Data struct {
-					Content string `json:"content"`
-				} `json:"data"`
-			} `json:"nodeView"`
-		} `json:"data"`
-		Parent *struct {
-			ID string `json:"id"`
-		} `json:"parent"`
-		Children []struct {
-			ID string `json:"id"`
-		} `json:"children"`
-		CreatedAt  string `json:"createdAt"`
-		ModifiedAt string `json:"modifiedAt"`
-	}
+	var node mindmapNodeResponse
 	if err := json.Unmarshal(respBody, &node); err != nil {
 		return GetMindmapNodeResult{}, fmt.Errorf("failed to parse response: %w", err)
 	}
 
-	result := GetMindmapNodeResult{
-		ID:       node.ID,
-		Content:  node.Data.NodeView.Data.Content,
-		NodeView: node.Data.NodeView.Type,
-		IsRoot:   node.Data.IsRoot,
-		Message:  fmt.Sprintf("Retrieved mindmap node '%s'", truncateMindmap(node.Data.NodeView.Data.Content, 30)),
-	}
+	return mindmapNodeDetails(node), nil
+}
 
+// mindmapNodeResponse mirrors the API's mindmap node payload.
+type mindmapNodeResponse struct {
+	ID       string `json:"id"`
+	Position *struct {
+		X float64 `json:"x"`
+		Y float64 `json:"y"`
+	} `json:"position"`
+	Data struct {
+		IsRoot   bool `json:"isRoot"`
+		NodeView struct {
+			Type string `json:"type"`
+			Data struct {
+				Content string `json:"content"`
+			} `json:"data"`
+		} `json:"nodeView"`
+	} `json:"data"`
+	Parent *struct {
+		ID string `json:"id"`
+	} `json:"parent"`
+	Children []struct {
+		ID string `json:"id"`
+	} `json:"children"`
+	CreatedAt  string `json:"createdAt"`
+	ModifiedAt string `json:"modifiedAt"`
+}
+
+// mindmapNodeDetails projects the API payload onto the get result.
+func mindmapNodeDetails(node mindmapNodeResponse) GetMindmapNodeResult {
+	result := GetMindmapNodeResult{
+		ID:         node.ID,
+		Content:    node.Data.NodeView.Data.Content,
+		NodeView:   node.Data.NodeView.Type,
+		IsRoot:     node.Data.IsRoot,
+		CreatedAt:  node.CreatedAt,
+		ModifiedAt: node.ModifiedAt,
+		Message:    fmt.Sprintf("Retrieved mindmap node '%s'", truncateMindmap(node.Data.NodeView.Data.Content, 30)),
+	}
 	if node.Position != nil {
 		result.X = node.Position.X
 		result.Y = node.Position.Y
@@ -189,10 +206,7 @@ func (c *Client) GetMindmapNode(ctx context.Context, args GetMindmapNodeArgs) (G
 			result.ChildIDs[i] = child.ID
 		}
 	}
-	result.CreatedAt = node.CreatedAt
-	result.ModifiedAt = node.ModifiedAt
-
-	return result, nil
+	return result
 }
 
 // ListMindmapNodes retrieves all mindmap nodes on a board.
@@ -201,13 +215,7 @@ func (c *Client) ListMindmapNodes(ctx context.Context, args ListMindmapNodesArgs
 		return ListMindmapNodesResult{}, err
 	}
 
-	limit := args.Limit
-	if limit <= 0 {
-		limit = 50
-	}
-	if limit > 100 {
-		limit = 100
-	}
+	limit := clampFrameItemsLimit(args.Limit)
 
 	path := fmt.Sprintf("/boards/%s/mindmap_nodes?limit=%d", args.BoardID, limit)
 	if args.Cursor != "" {
@@ -227,22 +235,23 @@ func (c *Client) ListMindmapNodes(ctx context.Context, args ListMindmapNodesArgs
 		return ListMindmapNodesResult{}, fmt.Errorf("failed to parse response: %w", err)
 	}
 
-	nodes := make([]MindmapNodeSummary, 0, len(resp.Data))
-	for _, raw := range resp.Data {
-		var node struct {
-			ID   string `json:"id"`
-			Data struct {
-				IsRoot   bool `json:"isRoot"`
-				NodeView struct {
-					Data struct {
-						Content string `json:"content"`
-					} `json:"data"`
-				} `json:"nodeView"`
-			} `json:"data"`
-			Parent *struct {
-				ID string `json:"id"`
-			} `json:"parent"`
-		}
+	nodes := parseMindmapNodeSummaries(resp.Data)
+
+	return ListMindmapNodesResult{
+		Nodes:   nodes,
+		Count:   len(nodes),
+		HasMore: resp.Cursor != "",
+		Cursor:  resp.Cursor,
+		Message: fmt.Sprintf("Found %d mindmap nodes", len(nodes)),
+	}, nil
+}
+
+// parseMindmapNodeSummaries converts raw list entries into summaries,
+// skipping entries that fail to parse.
+func parseMindmapNodeSummaries(entries []json.RawMessage) []MindmapNodeSummary {
+	nodes := make([]MindmapNodeSummary, 0, len(entries))
+	for _, raw := range entries {
+		var node mindmapNodeResponse
 		if err := json.Unmarshal(raw, &node); err != nil {
 			continue
 		}
@@ -257,14 +266,7 @@ func (c *Client) ListMindmapNodes(ctx context.Context, args ListMindmapNodesArgs
 		}
 		nodes = append(nodes, summary)
 	}
-
-	return ListMindmapNodesResult{
-		Nodes:   nodes,
-		Count:   len(nodes),
-		HasMore: resp.Cursor != "",
-		Cursor:  resp.Cursor,
-		Message: fmt.Sprintf("Found %d mindmap nodes", len(nodes)),
-	}, nil
+	return nodes
 }
 
 // DeleteMindmapNode removes a mindmap node.

--- a/miro/oauth/auth.go
+++ b/miro/oauth/auth.go
@@ -48,42 +48,15 @@ func (f *AuthFlow) Login(ctx context.Context) (*TokenSet, error) {
 	server.Start()
 	defer server.Stop(ctx)
 
-	// Get authorization URL
-	authURL := f.provider.GetAuthorizationURL(state)
-
-	// Open browser
-	f.logger.Info("Opening browser for authorization...", "url", authURL)
-	if err := openBrowser(authURL); err != nil {
-		f.logger.Warn("Failed to open browser automatically", "error", err)
-		fmt.Printf("\nPlease open this URL in your browser:\n%s\n\n", authURL)
-	}
-
-	// Wait for callback
-	f.logger.Info("Waiting for authorization...", "timeout", "5m")
-	result, err := server.WaitForCallback(ctx, 5*time.Minute)
+	// Run the browser round trip, then trade the code for stored tokens
+	code, err := f.authorize(ctx, server, state)
 	if err != nil {
-		return nil, fmt.Errorf("authorization failed: %w", err)
+		return nil, err
 	}
 
-	if result.Error != nil {
-		return nil, result.Error
-	}
-
-	// Verify state
-	if result.State != state.State {
-		return nil, fmt.Errorf("state mismatch: possible CSRF attack")
-	}
-
-	// Exchange code for tokens
-	f.logger.Info("Exchanging code for tokens...")
-	tokens, err := f.provider.ExchangeCode(ctx, result.Code, state.CodeVerifier)
+	tokens, err := f.exchangeAndStore(ctx, code, state)
 	if err != nil {
-		return nil, fmt.Errorf("token exchange failed: %w", err)
-	}
-
-	// Store tokens
-	if err := f.tokenStore.Save(ctx, tokens); err != nil {
-		return nil, fmt.Errorf("failed to save tokens: %w", err)
+		return nil, err
 	}
 
 	f.logger.Info("Authorization successful!",
@@ -92,6 +65,46 @@ func (f *AuthFlow) Login(ctx context.Context) (*TokenSet, error) {
 		"expires_at", tokens.ExpiresAt.Format(time.RFC3339),
 	)
 
+	return tokens, nil
+}
+
+// authorize opens the browser for the consent screen and waits for the
+// verified callback, returning the authorization code.
+func (f *AuthFlow) authorize(ctx context.Context, server *CallbackServer, state *AuthorizationState) (string, error) {
+	authURL := f.provider.GetAuthorizationURL(state)
+
+	f.logger.Info("Opening browser for authorization...", "url", authURL)
+	if err := openBrowser(authURL); err != nil {
+		f.logger.Warn("Failed to open browser automatically", "error", err)
+		fmt.Printf("\nPlease open this URL in your browser:\n%s\n\n", authURL)
+	}
+
+	f.logger.Info("Waiting for authorization...", "timeout", "5m")
+	result, err := server.WaitForCallback(ctx, 5*time.Minute)
+	if err != nil {
+		return "", fmt.Errorf("authorization failed: %w", err)
+	}
+	if result.Error != nil {
+		return "", result.Error
+	}
+	if result.State != state.State {
+		return "", fmt.Errorf("state mismatch: possible CSRF attack")
+	}
+	return result.Code, nil
+}
+
+// exchangeAndStore trades the authorization code for tokens and persists
+// them in the token store.
+func (f *AuthFlow) exchangeAndStore(ctx context.Context, code string, state *AuthorizationState) (*TokenSet, error) {
+	f.logger.Info("Exchanging code for tokens...")
+	tokens, err := f.provider.ExchangeCode(ctx, code, state.CodeVerifier)
+	if err != nil {
+		return nil, fmt.Errorf("token exchange failed: %w", err)
+	}
+
+	if err := f.tokenStore.Save(ctx, tokens); err != nil {
+		return nil, fmt.Errorf("failed to save tokens: %w", err)
+	}
 	return tokens, nil
 }
 

--- a/miro/tags.go
+++ b/miro/tags.go
@@ -126,52 +126,55 @@ func tagItemPath(boardID, itemID, tagID string) string {
 	return fmt.Sprintf("/boards/%s/items/%s?tag_id=%s", boardID, itemID, tagID)
 }
 
-// runTagItemAction validates args, executes the request, and returns the four
-// fields the typed AttachTag/DetachTag wrappers need:
-//   - filled: false on validation error (caller returns zero result + err)
-//   - success: meaningful only when filled=true
-//   - message: success or failure text to populate the result's Message field
-//   - err: raw error from validation or the HTTP request
-func (c *Client) runTagItemAction(ctx context.Context, req tagItemRequest) (filled bool, success bool, message string, err error) {
+// runTagItemAction validates args, executes the request, and shapes the
+// shared result for the AttachTag/DetachTag wrappers. On validation error it
+// returns a zero result; on request error it returns a populated failure
+// result alongside the error.
+func (c *Client) runTagItemAction(ctx context.Context, req tagItemRequest) (TagItemResult, error) {
 	if err := validateTagItemRequest(req); err != nil {
-		return false, false, "", err
+		return TagItemResult{}, err
 	}
+	result := TagItemResult{ItemID: req.itemID, TagID: req.tagID}
 	if _, err := c.request(ctx, req.method, tagItemPath(req.boardID, req.itemID, req.tagID), nil); err != nil {
-		return true, false, fmt.Sprintf("Failed to %s tag: %v", req.failureVerb, err), err
+		result.Message = fmt.Sprintf("Failed to %s tag: %v", req.failureVerb, err)
+		return result, err
 	}
-	return true, true, req.successMsg, nil
+	result.Success = true
+	result.Message = req.successMsg
+	return result, nil
+}
+
+// attachTagAction and detachTagAction are the per-verb templates for the
+// two tag item operations; withIDs fills in the target identifiers.
+var (
+	attachTagAction = tagItemRequest{
+		method:      http.MethodPost,
+		successMsg:  "Tag attached successfully",
+		failureVerb: "attach",
+	}
+	detachTagAction = tagItemRequest{
+		method:      http.MethodDelete,
+		successMsg:  "Tag removed successfully",
+		failureVerb: "detach",
+	}
+)
+
+// withIDs returns a copy of the template with the target identifiers set.
+func (r tagItemRequest) withIDs(boardID, itemID, tagID string) tagItemRequest {
+	r.boardID = boardID
+	r.itemID = itemID
+	r.tagID = tagID
+	return r
 }
 
 // AttachTag attaches a tag to an item (sticky note).
 func (c *Client) AttachTag(ctx context.Context, args AttachTagArgs) (AttachTagResult, error) {
-	filled, success, msg, err := c.runTagItemAction(ctx, tagItemRequest{
-		method:      http.MethodPost,
-		successMsg:  "Tag attached successfully",
-		failureVerb: "attach",
-		boardID:     args.BoardID,
-		itemID:      args.ItemID,
-		tagID:       args.TagID,
-	})
-	if !filled {
-		return AttachTagResult{}, err
-	}
-	return AttachTagResult{Success: success, ItemID: args.ItemID, TagID: args.TagID, Message: msg}, err
+	return c.runTagItemAction(ctx, attachTagAction.withIDs(args.BoardID, args.ItemID, args.TagID))
 }
 
 // DetachTag removes a tag from an item.
 func (c *Client) DetachTag(ctx context.Context, args DetachTagArgs) (DetachTagResult, error) {
-	filled, success, msg, err := c.runTagItemAction(ctx, tagItemRequest{
-		method:      http.MethodDelete,
-		successMsg:  "Tag removed successfully",
-		failureVerb: "detach",
-		boardID:     args.BoardID,
-		itemID:      args.ItemID,
-		tagID:       args.TagID,
-	})
-	if !filled {
-		return DetachTagResult{}, err
-	}
-	return DetachTagResult{Success: success, ItemID: args.ItemID, TagID: args.TagID, Message: msg}, err
+	return c.runTagItemAction(ctx, detachTagAction.withIDs(args.BoardID, args.ItemID, args.TagID))
 }
 
 // GetItemTags retrieves tags attached to an item.

--- a/miro/text.go
+++ b/miro/text.go
@@ -12,15 +12,9 @@ import (
 // Text Operations - Create, Update
 // =============================================================================
 
-// CreateText creates a text item on a board.
-func (c *Client) CreateText(ctx context.Context, args CreateTextArgs) (CreateTextResult, error) {
-	if err := ValidateBoardID(args.BoardID); err != nil {
-		return CreateTextResult{}, err
-	}
-	if args.Content == "" {
-		return CreateTextResult{}, fmt.Errorf("content is required")
-	}
-
+// buildCreateTextBody assembles the POST body for a text create, including
+// the optional style, geometry, and parent sections.
+func buildCreateTextBody(args CreateTextArgs) (map[string]interface{}, error) {
 	reqBody := map[string]interface{}{
 		"data": map[string]interface{}{
 			"content": args.Content,
@@ -32,16 +26,9 @@ func (c *Client) CreateText(ctx context.Context, args CreateTextArgs) (CreateTex
 		},
 	}
 
-	style := make(map[string]interface{})
-	if args.FontSize > 0 {
-		style["fontSize"] = strconv.Itoa(args.FontSize)
-	}
-	if args.Color != "" {
-		color, err := normalizeColor(args.Color)
-		if err != nil {
-			return CreateTextResult{}, fmt.Errorf("color: %w", err)
-		}
-		style["color"] = color
+	style, err := buildCreateTextStyle(args)
+	if err != nil {
+		return nil, err
 	}
 	if len(style) > 0 {
 		reqBody["style"] = style
@@ -52,11 +39,60 @@ func (c *Client) CreateText(ctx context.Context, args CreateTextArgs) (CreateTex
 			"width": args.Width,
 		}
 	}
-
 	if args.ParentID != "" {
 		reqBody["parent"] = map[string]interface{}{
 			"id": args.ParentID,
 		}
+	}
+	return reqBody, nil
+}
+
+// buildCreateTextStyle assembles the optional style block for a text create
+// by lifting the set fields into the shared optional-style builder.
+func buildCreateTextStyle(args CreateTextArgs) (map[string]interface{}, error) {
+	var fontSize *int
+	if args.FontSize > 0 {
+		fontSize = &args.FontSize
+	}
+	var color *string
+	if args.Color != "" {
+		color = &args.Color
+	}
+	return textStyle(fontSize, nil, color)
+}
+
+// textStyle builds a style map from the optional font size, alignment, and
+// color shared by text create and update.
+func textStyle(fontSize *int, textAlign, color *string) (map[string]interface{}, error) {
+	style := make(map[string]interface{})
+	if fontSize != nil {
+		style["fontSize"] = strconv.Itoa(*fontSize)
+	}
+	if textAlign != nil {
+		style["textAlign"] = *textAlign
+	}
+	if color != nil {
+		normalized, err := normalizeColor(*color)
+		if err != nil {
+			return nil, fmt.Errorf("color: %w", err)
+		}
+		style["color"] = normalized
+	}
+	return style, nil
+}
+
+// CreateText creates a text item on a board.
+func (c *Client) CreateText(ctx context.Context, args CreateTextArgs) (CreateTextResult, error) {
+	if err := ValidateBoardID(args.BoardID); err != nil {
+		return CreateTextResult{}, err
+	}
+	if args.Content == "" {
+		return CreateTextResult{}, fmt.Errorf("content is required")
+	}
+
+	reqBody, err := buildCreateTextBody(args)
+	if err != nil {
+		return CreateTextResult{}, err
 	}
 
 	respBody, err := c.request(ctx, http.MethodPost, "/boards/"+args.BoardID+"/texts", reqBody)
@@ -82,21 +118,7 @@ func (c *Client) CreateText(ctx context.Context, args CreateTextArgs) (CreateTex
 
 // buildTextStyleSection returns the optional "style" map for a text update.
 func buildTextStyleSection(args UpdateTextArgs) (map[string]interface{}, error) {
-	style := make(map[string]interface{})
-	if args.FontSize != nil {
-		style["fontSize"] = fmt.Sprintf("%d", *args.FontSize)
-	}
-	if args.TextAlign != nil {
-		style["textAlign"] = *args.TextAlign
-	}
-	if args.Color != nil {
-		color, err := normalizeColor(*args.Color)
-		if err != nil {
-			return nil, fmt.Errorf("color: %w", err)
-		}
-		style["color"] = color
-	}
-	return style, nil
+	return textStyle(args.FontSize, args.TextAlign, args.Color)
 }
 
 // buildPositionSection returns the optional "position" map when X or Y is set.

--- a/miro/types_tags.go
+++ b/miro/types_tags.go
@@ -59,13 +59,16 @@ type AttachTagArgs struct {
 	TagID   string `json:"tag_id" jsonschema:"ID of the tag to attach"`
 }
 
-// AttachTagResult confirms tag attachment.
-type AttachTagResult struct {
+// TagItemResult is the shared outcome of attaching or detaching a tag.
+type TagItemResult struct {
 	Success bool   `json:"success"`
 	ItemID  string `json:"item_id"`
 	TagID   string `json:"tag_id"`
 	Message string `json:"message"`
 }
+
+// AttachTagResult confirms tag attachment.
+type AttachTagResult = TagItemResult
 
 // =============================================================================
 // Detach Tag
@@ -79,12 +82,7 @@ type DetachTagArgs struct {
 }
 
 // DetachTagResult confirms tag removal.
-type DetachTagResult struct {
-	Success bool   `json:"success"`
-	ItemID  string `json:"item_id"`
-	TagID   string `json:"tag_id"`
-	Message string `json:"message"`
-}
+type DetachTagResult = TagItemResult
 
 // =============================================================================
 // Get Item Tags

--- a/miro/types_upload.go
+++ b/miro/types_upload.go
@@ -14,13 +14,18 @@ type UploadImageArgs struct {
 	ParentID string  `json:"parent_id,omitempty" jsonschema:"Frame ID to place image in"`
 }
 
-// UploadImageResult contains the uploaded image details.
-type UploadImageResult struct {
+// UploadedItemResult contains the details of an item created or updated
+// through a multipart file upload. All four upload/update-from-file tools
+// return this shape.
+type UploadedItemResult struct {
 	ID      string `json:"id"`
 	ItemURL string `json:"item_url,omitempty"`
 	Title   string `json:"title,omitempty"`
 	Message string `json:"message"`
 }
+
+// UploadImageResult contains the uploaded image details.
+type UploadImageResult = UploadedItemResult
 
 // =============================================================================
 // Upload Document (File Upload)
@@ -37,12 +42,7 @@ type UploadDocumentArgs struct {
 }
 
 // UploadDocumentResult contains the uploaded document details.
-type UploadDocumentResult struct {
-	ID      string `json:"id"`
-	ItemURL string `json:"item_url,omitempty"`
-	Title   string `json:"title,omitempty"`
-	Message string `json:"message"`
-}
+type UploadDocumentResult = UploadedItemResult
 
 // =============================================================================
 // Update Image from File (PATCH multipart)
@@ -60,12 +60,7 @@ type UpdateImageFromFileArgs struct {
 }
 
 // UpdateImageFromFileResult contains the updated image details.
-type UpdateImageFromFileResult struct {
-	ID      string `json:"id"`
-	ItemURL string `json:"item_url,omitempty"`
-	Title   string `json:"title,omitempty"`
-	Message string `json:"message"`
-}
+type UpdateImageFromFileResult = UploadedItemResult
 
 // =============================================================================
 // Update Document from File (PATCH multipart)
@@ -83,9 +78,4 @@ type UpdateDocumentFromFileArgs struct {
 }
 
 // UpdateDocumentFromFileResult contains the updated document details.
-type UpdateDocumentFromFileResult struct {
-	ID      string `json:"id"`
-	ItemURL string `json:"item_url,omitempty"`
-	Title   string `json:"title,omitempty"`
-	Message string `json:"message"`
-}
+type UpdateDocumentFromFileResult = UploadedItemResult

--- a/miro/upload.go
+++ b/miro/upload.go
@@ -227,134 +227,124 @@ type uploadFormOpts struct {
 	parentID string
 }
 
-// UploadImage uploads a local image file to a Miro board.
-func (c *Client) UploadImage(ctx context.Context, args UploadImageArgs) (UploadImageResult, error) {
-	if err := ValidateBoardID(args.BoardID); err != nil {
-		return UploadImageResult{}, err
-	}
-	resolvedPath, err := validateImageFile(args.FilePath)
-	if err != nil {
-		return UploadImageResult{}, err
-	}
+// uploadKind bundles the per-item-type differences (API path segment, file
+// validator, display noun) between image and document uploads.
+type uploadKind struct {
+	segment  string
+	validate func(string) (string, error)
+	noun     string
+}
 
-	parsed, err := c.uploadMultipart(ctx, multipartUploadCall{
-		method:        http.MethodPost,
-		path:          "/boards/" + args.BoardID + "/images",
-		boardID:       args.BoardID,
-		filePath:      args.FilePath,
+var (
+	imageUploads    = uploadKind{segment: "images", validate: validateImageFile, noun: "image"}
+	documentUploads = uploadKind{segment: "documents", validate: validateDocumentFile, noun: "document"}
+)
+
+// uploadRequest is one upload or update-from-file operation: the target kind
+// and board, an optional existing item to replace, the local file, and the
+// shared form fields.
+type uploadRequest struct {
+	kind     uploadKind
+	boardID  string
+	itemID   string // item whose file is being replaced; used when replace is set
+	replace  bool   // true for update-from-file calls, false for new uploads
+	filePath string
+	form     uploadFormOpts
+}
+
+// message renders the user-facing confirmation for a completed operation.
+func (r uploadRequest) message(title string) string {
+	if r.replace {
+		return fmt.Sprintf("Updated %s '%s' with new file", r.kind.noun, title)
+	}
+	return fmt.Sprintf("Uploaded %s '%s'", r.kind.noun, title)
+}
+
+// runUpload validates the request and performs the shared multipart flow.
+// New uploads POST to the collection path; replacements PATCH the item path.
+func (c *Client) runUpload(ctx context.Context, req uploadRequest) (uploadAPIResponse, error) {
+	if err := ValidateBoardID(req.boardID); err != nil {
+		return uploadAPIResponse{}, err
+	}
+	method := http.MethodPost
+	path := "/boards/" + req.boardID + "/" + req.kind.segment
+	if req.replace {
+		if err := ValidateItemID(req.itemID); err != nil {
+			return uploadAPIResponse{}, err
+		}
+		method = http.MethodPatch
+		path += "/" + req.itemID
+	}
+	resolvedPath, err := req.kind.validate(req.filePath)
+	if err != nil {
+		return uploadAPIResponse{}, err
+	}
+	return c.uploadMultipart(ctx, multipartUploadCall{
+		method:        method,
+		path:          path,
+		boardID:       req.boardID,
+		filePath:      req.filePath,
 		resolvedPath:  resolvedPath,
-		form:          uploadFormOpts{title: args.Title, x: args.X, y: args.Y, parentID: args.ParentID},
-		fallbackTitle: filepath.Base(args.FilePath),
+		form:          req.form,
+		fallbackTitle: filepath.Base(req.filePath),
 	})
-	if err != nil {
-		return UploadImageResult{}, err
-	}
+}
 
-	return UploadImageResult{
+// runUploadResult runs the upload and shapes the shared result type.
+func (c *Client) runUploadResult(ctx context.Context, req uploadRequest) (UploadedItemResult, error) {
+	parsed, err := c.runUpload(ctx, req)
+	if err != nil {
+		return UploadedItemResult{}, err
+	}
+	return UploadedItemResult{
 		ID:      parsed.ID,
 		ItemURL: parsed.ItemURL,
 		Title:   parsed.Title,
-		Message: fmt.Sprintf("Uploaded image '%s'", parsed.Title),
+		Message: req.message(parsed.Title),
 	}, nil
+}
+
+// newUpload shapes a create-style upload request for the given kind.
+func newUpload(kind uploadKind, boardID, filePath string, form uploadFormOpts) uploadRequest {
+	return uploadRequest{kind: kind, boardID: boardID, filePath: filePath, form: form}
+}
+
+// withReplace marks the request as an update-from-file call targeting itemID.
+func (r uploadRequest) withReplace(itemID string) uploadRequest {
+	r.itemID = itemID
+	r.replace = true
+	return r
+}
+
+// formOf collects the shared optional form fields (title, position, parent).
+func formOf(title string, x, y float64, parentID string) uploadFormOpts {
+	return uploadFormOpts{title: title, x: x, y: y, parentID: parentID}
+}
+
+// UploadImage uploads a local image file to a Miro board.
+func (c *Client) UploadImage(ctx context.Context, args UploadImageArgs) (UploadImageResult, error) {
+	form := formOf(args.Title, args.X, args.Y, args.ParentID)
+	return c.runUploadResult(ctx, newUpload(imageUploads, args.BoardID, args.FilePath, form))
 }
 
 // UploadDocument uploads a local document file to a Miro board.
 func (c *Client) UploadDocument(ctx context.Context, args UploadDocumentArgs) (UploadDocumentResult, error) {
-	if err := ValidateBoardID(args.BoardID); err != nil {
-		return UploadDocumentResult{}, err
-	}
-	resolvedPath, err := validateDocumentFile(args.FilePath)
-	if err != nil {
-		return UploadDocumentResult{}, err
-	}
-
-	parsed, err := c.uploadMultipart(ctx, multipartUploadCall{
-		method:        http.MethodPost,
-		path:          "/boards/" + args.BoardID + "/documents",
-		boardID:       args.BoardID,
-		filePath:      args.FilePath,
-		resolvedPath:  resolvedPath,
-		form:          uploadFormOpts{title: args.Title, x: args.X, y: args.Y, parentID: args.ParentID},
-		fallbackTitle: filepath.Base(args.FilePath),
-	})
-	if err != nil {
-		return UploadDocumentResult{}, err
-	}
-
-	return UploadDocumentResult{
-		ID:      parsed.ID,
-		ItemURL: parsed.ItemURL,
-		Title:   parsed.Title,
-		Message: fmt.Sprintf("Uploaded document '%s'", parsed.Title),
-	}, nil
+	form := formOf(args.Title, args.X, args.Y, args.ParentID)
+	return c.runUploadResult(ctx, newUpload(documentUploads, args.BoardID, args.FilePath, form))
 }
 
 // UpdateImageFromFile replaces the file on an existing image item via PATCH multipart.
 func (c *Client) UpdateImageFromFile(ctx context.Context, args UpdateImageFromFileArgs) (UpdateImageFromFileResult, error) {
-	if err := ValidateBoardID(args.BoardID); err != nil {
-		return UpdateImageFromFileResult{}, err
-	}
-	if err := ValidateItemID(args.ItemID); err != nil {
-		return UpdateImageFromFileResult{}, err
-	}
-	resolvedPath, err := validateImageFile(args.FilePath)
-	if err != nil {
-		return UpdateImageFromFileResult{}, err
-	}
-
-	parsed, err := c.uploadMultipart(ctx, multipartUploadCall{
-		method:        http.MethodPatch,
-		path:          "/boards/" + args.BoardID + "/images/" + args.ItemID,
-		boardID:       args.BoardID,
-		filePath:      args.FilePath,
-		resolvedPath:  resolvedPath,
-		form:          uploadFormOpts{title: args.Title, x: args.X, y: args.Y, parentID: args.ParentID},
-		fallbackTitle: filepath.Base(args.FilePath),
-	})
-	if err != nil {
-		return UpdateImageFromFileResult{}, err
-	}
-
-	return UpdateImageFromFileResult{
-		ID:      parsed.ID,
-		ItemURL: parsed.ItemURL,
-		Title:   parsed.Title,
-		Message: fmt.Sprintf("Updated image '%s' with new file", parsed.Title),
-	}, nil
+	form := formOf(args.Title, args.X, args.Y, args.ParentID)
+	req := newUpload(imageUploads, args.BoardID, args.FilePath, form).withReplace(args.ItemID)
+	return c.runUploadResult(ctx, req)
 }
 
 // UpdateDocumentFromFile replaces the file on an existing document item via PATCH multipart.
 func (c *Client) UpdateDocumentFromFile(ctx context.Context, args UpdateDocumentFromFileArgs) (UpdateDocumentFromFileResult, error) {
-	if err := ValidateBoardID(args.BoardID); err != nil {
-		return UpdateDocumentFromFileResult{}, err
-	}
-	if err := ValidateItemID(args.ItemID); err != nil {
-		return UpdateDocumentFromFileResult{}, err
-	}
-	resolvedPath, err := validateDocumentFile(args.FilePath)
-	if err != nil {
-		return UpdateDocumentFromFileResult{}, err
-	}
-
-	parsed, err := c.uploadMultipart(ctx, multipartUploadCall{
-		method:        http.MethodPatch,
-		path:          "/boards/" + args.BoardID + "/documents/" + args.ItemID,
-		boardID:       args.BoardID,
-		filePath:      args.FilePath,
-		resolvedPath:  resolvedPath,
-		form:          uploadFormOpts{title: args.Title, x: args.X, y: args.Y, parentID: args.ParentID},
-		fallbackTitle: filepath.Base(args.FilePath),
-	})
-	if err != nil {
-		return UpdateDocumentFromFileResult{}, err
-	}
-
-	return UpdateDocumentFromFileResult{
-		ID:      parsed.ID,
-		ItemURL: parsed.ItemURL,
-		Title:   parsed.Title,
-		Message: fmt.Sprintf("Updated document '%s' with new file", parsed.Title),
-	}, nil
+	form := formOf(args.Title, args.X, args.Y, args.ParentID)
+	req := newUpload(documentUploads, args.BoardID, args.FilePath, form).withReplace(args.ItemID)
+	return c.runUploadResult(ctx, req)
 }
 
 // multipartUploadCall bundles the per-call inputs for the shared upload skeleton.

--- a/prompts/prompts.go
+++ b/prompts/prompts.go
@@ -17,102 +17,73 @@ func NewRegistry() *Registry {
 	return &Registry{}
 }
 
+// promptSpec pairs a prompt definition with its handler for registration.
+type promptSpec struct {
+	prompt  *mcp.Prompt
+	handler mcp.PromptHandler
+}
+
+// arg builds a prompt argument definition.
+func arg(name, description string, required bool) *mcp.PromptArgument {
+	return &mcp.PromptArgument{Name: name, Description: description, Required: required}
+}
+
+// specs lists every Miro workflow prompt and its handler.
+func (r *Registry) specs() []promptSpec {
+	return []promptSpec{
+		{&mcp.Prompt{
+			Name:        "create-sprint-board",
+			Title:       "Create Sprint Board",
+			Description: "Create a sprint planning board with standard sections for backlog, in progress, review, and done.",
+			Arguments: []*mcp.PromptArgument{
+				arg("board_name", "Name for the new sprint board", true),
+				arg("sprint_number", "Sprint number (e.g., '42')", false),
+			},
+		}, r.handleSprintBoard},
+		{&mcp.Prompt{
+			Name:        "create-retrospective",
+			Title:       "Create Retrospective Board",
+			Description: "Create a retrospective board with sections for what went well, what could improve, and action items.",
+			Arguments: []*mcp.PromptArgument{
+				arg("board_id", "Board ID to add retrospective sections to (creates new if not provided)", false),
+				arg("team_name", "Team name for the retrospective", false),
+			},
+		}, r.handleRetrospective},
+		{&mcp.Prompt{
+			Name:        "create-brainstorm",
+			Title:       "Create Brainstorming Session",
+			Description: "Set up a brainstorming board with a central topic and space for ideas.",
+			Arguments: []*mcp.PromptArgument{
+				arg("topic", "Central topic or question for brainstorming", true),
+				arg("board_id", "Existing board ID (creates new if not provided)", false),
+			},
+		}, r.handleBrainstorm},
+		{&mcp.Prompt{
+			Name:        "create-story-map",
+			Title:       "Create User Story Map",
+			Description: "Create a user story mapping board with activities, user tasks, and story cards.",
+			Arguments: []*mcp.PromptArgument{
+				arg("product_name", "Name of the product being mapped", true),
+				arg("board_id", "Existing board ID (creates new if not provided)", false),
+			},
+		}, r.handleStoryMap},
+		{&mcp.Prompt{
+			Name:        "create-kanban",
+			Title:       "Create Kanban Board",
+			Description: "Create a kanban board with customizable columns for workflow management.",
+			Arguments: []*mcp.PromptArgument{
+				arg("board_name", "Name for the kanban board", true),
+				arg("columns", "Comma-separated column names (default: To Do,In Progress,Review,Done)", false),
+			},
+		}, r.handleKanban},
+	}
+}
+
 // RegisterAll registers all Miro prompts with the MCP server.
 func (r *Registry) RegisterAll(server *mcp.Server) {
-	// Sprint Board prompt
-	server.AddPrompt(&mcp.Prompt{
-		Name:        "create-sprint-board",
-		Title:       "Create Sprint Board",
-		Description: "Create a sprint planning board with standard sections for backlog, in progress, review, and done.",
-		Arguments: []*mcp.PromptArgument{
-			{
-				Name:        "board_name",
-				Description: "Name for the new sprint board",
-				Required:    true,
-			},
-			{
-				Name:        "sprint_number",
-				Description: "Sprint number (e.g., '42')",
-				Required:    false,
-			},
-		},
-	}, r.handleSprintBoard)
-
-	// Retrospective prompt
-	server.AddPrompt(&mcp.Prompt{
-		Name:        "create-retrospective",
-		Title:       "Create Retrospective Board",
-		Description: "Create a retrospective board with sections for what went well, what could improve, and action items.",
-		Arguments: []*mcp.PromptArgument{
-			{
-				Name:        "board_id",
-				Description: "Board ID to add retrospective sections to (creates new if not provided)",
-				Required:    false,
-			},
-			{
-				Name:        "team_name",
-				Description: "Team name for the retrospective",
-				Required:    false,
-			},
-		},
-	}, r.handleRetrospective)
-
-	// Brainstorming prompt
-	server.AddPrompt(&mcp.Prompt{
-		Name:        "create-brainstorm",
-		Title:       "Create Brainstorming Session",
-		Description: "Set up a brainstorming board with a central topic and space for ideas.",
-		Arguments: []*mcp.PromptArgument{
-			{
-				Name:        "topic",
-				Description: "Central topic or question for brainstorming",
-				Required:    true,
-			},
-			{
-				Name:        "board_id",
-				Description: "Existing board ID (creates new if not provided)",
-				Required:    false,
-			},
-		},
-	}, r.handleBrainstorm)
-
-	// User Story Map prompt
-	server.AddPrompt(&mcp.Prompt{
-		Name:        "create-story-map",
-		Title:       "Create User Story Map",
-		Description: "Create a user story mapping board with activities, user tasks, and story cards.",
-		Arguments: []*mcp.PromptArgument{
-			{
-				Name:        "product_name",
-				Description: "Name of the product being mapped",
-				Required:    true,
-			},
-			{
-				Name:        "board_id",
-				Description: "Existing board ID (creates new if not provided)",
-				Required:    false,
-			},
-		},
-	}, r.handleStoryMap)
-
-	// Kanban Board prompt
-	server.AddPrompt(&mcp.Prompt{
-		Name:        "create-kanban",
-		Title:       "Create Kanban Board",
-		Description: "Create a kanban board with customizable columns for workflow management.",
-		Arguments: []*mcp.PromptArgument{
-			{
-				Name:        "board_name",
-				Description: "Name for the kanban board",
-				Required:    true,
-			},
-			{
-				Name:        "columns",
-				Description: "Comma-separated column names (default: To Do,In Progress,Review,Done)",
-				Required:    false,
-			},
-		},
-	}, r.handleKanban)
+	for _, spec := range r.specs() {
+		server.AddPrompt(spec.prompt, spec.handler)
+	}
 }
 
 // handleSprintBoard generates a sprint board creation prompt

--- a/tools/handlers.go
+++ b/tools/handlers.go
@@ -422,6 +422,14 @@ func (h *HandlerRegistry) logExecution(spec ToolSpec, args, result any) {
 // argAttrs extracts log attributes specific to known argument types. Returns
 // nil for types that don't carry loggable context.
 func argAttrs(args any) []any {
+	if attrs := readArgAttrs(args); attrs != nil {
+		return attrs
+	}
+	return writeArgAttrs(args)
+}
+
+// readArgAttrs covers read/list argument types.
+func readArgAttrs(args any) []any {
 	switch a := args.(type) {
 	case miro.ListBoardsArgs:
 		if a.Query != "" {
@@ -429,12 +437,19 @@ func argAttrs(args any) []any {
 		}
 	case miro.GetBoardArgs:
 		return []any{"board_id", a.BoardID}
+	case miro.ListItemsArgs:
+		return []any{"board_id", a.BoardID, "type", a.Type}
+	}
+	return nil
+}
+
+// writeArgAttrs covers create/delete argument types.
+func writeArgAttrs(args any) []any {
+	switch a := args.(type) {
 	case miro.CreateStickyArgs:
 		return []any{"board_id", a.BoardID, "content_len", len(a.Content)}
 	case miro.CreateShapeArgs:
 		return []any{"board_id", a.BoardID, "shape", a.Shape}
-	case miro.ListItemsArgs:
-		return []any{"board_id", a.BoardID, "type", a.Type}
 	case miro.BulkCreateArgs:
 		return []any{"board_id", a.BoardID, "items_count", len(a.Items)}
 	case miro.DeleteItemArgs:

--- a/tools/search.go
+++ b/tools/search.go
@@ -78,26 +78,29 @@ func (h *HandlerRegistry) SearchTools(_ context.Context, args ToolSearchArgs) (T
 	}, nil
 }
 
-// scoreTools is the deterministic ranking step. Exposed for testability.
-func scoreTools(args ToolSearchArgs, tools []ToolSpec) []ToolSearchMatch {
-	limit := args.Limit
+// scoredTool pairs a tool spec with its relevance score during ranking.
+type scoredTool struct {
+	spec  ToolSpec
+	score float64
+}
+
+// clampSearchLimit bounds the result count with a default of 10, max 50.
+func clampSearchLimit(limit int) int {
 	switch {
 	case limit <= 0:
-		limit = 10
+		return 10
 	case limit > 50:
-		limit = 50
+		return 50
+	default:
+		return limit
 	}
+}
 
-	query := strings.ToLower(strings.TrimSpace(args.Query))
-	terms := tokenize(query)
-	categoryFilter := strings.ToLower(strings.TrimSpace(args.Category))
-
-	type scored struct {
-		spec  ToolSpec
-		score float64
-	}
-
-	candidates := make([]scored, 0, len(tools))
+// collectCandidates filters and scores the tool specs for a query. When the
+// query is empty, every tool in the category is kept at score 0 so the
+// caller's sort falls back to alphabetical order.
+func collectCandidates(tools []ToolSpec, terms []string, query, categoryFilter string) []scoredTool {
+	candidates := make([]scoredTool, 0, len(tools))
 	for _, t := range tools {
 		// Don't recommend the search tool itself; that's a recursion trap.
 		if t.Name == ToolSearchName {
@@ -109,14 +112,26 @@ func scoreTools(args ToolSearchArgs, tools []ToolSpec) []ToolSearchMatch {
 		s := computeScore(t, terms)
 		// When there's no query, fall back to alphabetical within the category.
 		if query == "" {
-			candidates = append(candidates, scored{spec: t, score: 0})
+			candidates = append(candidates, scoredTool{spec: t, score: 0})
 			continue
 		}
 		if s == 0 {
 			continue
 		}
-		candidates = append(candidates, scored{spec: t, score: s})
+		candidates = append(candidates, scoredTool{spec: t, score: s})
 	}
+	return candidates
+}
+
+// scoreTools is the deterministic ranking step. Exposed for testability.
+func scoreTools(args ToolSearchArgs, tools []ToolSpec) []ToolSearchMatch {
+	limit := clampSearchLimit(args.Limit)
+
+	query := strings.ToLower(strings.TrimSpace(args.Query))
+	terms := tokenize(query)
+	categoryFilter := strings.ToLower(strings.TrimSpace(args.Category))
+
+	candidates := collectCandidates(tools, terms, query, categoryFilter)
 
 	sort.SliceStable(candidates, func(i, j int) bool {
 		if candidates[i].score != candidates[j].score {
@@ -234,18 +249,37 @@ func shortenDescription(desc string, maxLen int) string {
 
 // buildSearchMessage produces a short status string for voice/log output.
 func buildSearchMessage(args ToolSearchArgs, matches []ToolSearchMatch) string {
+	if len(matches) == 0 {
+		if msg := noMatchMessage(args); msg != "" {
+			return msg
+		}
+	}
+	return foundMessage(args, len(matches))
+}
+
+// noMatchMessage describes an empty result. Returns "" when neither a query
+// nor a category was supplied, so the caller reports the generic count.
+func noMatchMessage(args ToolSearchArgs) string {
 	switch {
-	case len(matches) == 0 && args.Query != "" && args.Category != "":
+	case args.Query != "" && args.Category != "":
 		return fmt.Sprintf("No tools matched query %q in category %q", args.Query, args.Category)
-	case len(matches) == 0 && args.Query != "":
+	case args.Query != "":
 		return fmt.Sprintf("No tools matched query %q", args.Query)
-	case len(matches) == 0 && args.Category != "":
-		return fmt.Sprintf("No tools in category %q", args.Category)
-	case args.Query == "" && args.Category != "":
-		return fmt.Sprintf("Found %d tools in category %q", len(matches), args.Category)
 	case args.Category != "":
-		return fmt.Sprintf("Found %d tools matching %q in category %q", len(matches), args.Query, args.Category)
+		return fmt.Sprintf("No tools in category %q", args.Category)
 	default:
-		return fmt.Sprintf("Found %d tools matching %q", len(matches), args.Query)
+		return ""
+	}
+}
+
+// foundMessage describes a non-empty (or unfiltered) result.
+func foundMessage(args ToolSearchArgs, count int) string {
+	switch {
+	case args.Query == "" && args.Category != "":
+		return fmt.Sprintf("Found %d tools in category %q", count, args.Category)
+	case args.Category != "":
+		return fmt.Sprintf("Found %d tools matching %q in category %q", count, args.Query, args.Category)
+	default:
+		return fmt.Sprintf("Found %d tools matching %q", count, args.Query)
 	}
 }

--- a/tools/share_allowlist.go
+++ b/tools/share_allowlist.go
@@ -273,8 +273,20 @@ func (a *ShareAllowlist) Validate(email string) error {
 func extractDomain(email string) (string, bool) {
 	email = strings.TrimSpace(strings.ToLower(email))
 	at := strings.Index(email, "@")
-	if at <= 0 || at != strings.LastIndex(email, "@") || at == len(email)-1 {
+	if malformedEmailShape(email, at) {
 		return "", false
 	}
 	return email[at+1:], true
+}
+
+// malformedEmailShape reports whether the '@' position marks an invalid
+// address: missing or leading '@', multiple '@'s, or nothing after it.
+func malformedEmailShape(email string, at int) bool {
+	if at <= 0 {
+		return true
+	}
+	if at != strings.LastIndex(email, "@") {
+		return true
+	}
+	return at == len(email)-1
 }


### PR DESCRIPTION
## Summary

Full-repo CodeScene Code Health sweep (all 99 non-test Go files >= 40 lines) plus README badge cleanup. All refactors are behavior-preserving: extract-function/extract-helper only, no public API signature changes (two result-type consolidations use Go type aliases, so JSON shapes and call sites are unchanged). Test files untouched.

## Before / after (files that were below 10.0)

| File | Before | After | Smell fixed |
|---|---|---|---|
| miro/codewidgets.go | 8.53 | 9.68 | Complex methods, complex conditional, duplication |
| miro/upload.go | 9.09 | 9.38 | 4-way duplication -> single runUpload flow |
| miro/connectors.go | 9.21 | **10.0** | 4 complex methods |
| miro/frames.go | 9.30 | **10.0** | 3 complex methods |
| miro/export.go | 9.38 | **10.0** | Complex method + conditional |
| miro/metrics.go | 9.38 | **10.0** | 5- and 7-arg functions -> promMetric |
| miro/tags.go | 9.38 | **10.0** | Attach/detach duplication |
| miro/bulk.go | 9.38 | 9.38 | Skeleton deduped (runBulkOp); residual below |
| miro/mindmaps.go | 9.44 | **10.0** | 3 complex methods |
| prompts/prompts.go | 9.51 | **10.0** | 87-line RegisterAll -> spec table |
| tools/search.go | 9.57 | **10.0** | 2 complex methods |
| miro/diagrams/types.go | 9.61 | **10.0** | Bumpy road + complex method (Kahn sort) |
| miro/image.go | 9.66 | **10.0** | 2 complex methods |
| miro/document.go | 9.66 | **10.0** | 2 complex methods |
| tools/handlers.go | 9.68 | **10.0** | Complex type switch |
| miro/diagrams.go | 9.68 | **10.0** | Excess function arguments |
| miro/boards_summary.go | 9.68 | **10.0** | Excess function arguments |
| tools/share_allowlist.go | 9.68 | 9.68 | Complex conditional fixed; residual below |
| miro/boards.go | 9.68 | **10.0** | ListBoards cc15 + boardFields dedup |
| miro/groups.go | 9.68 | 9.38 | 1 complex method fixed; residual below |
| miro/docs.go | 9.68 | **10.0** | Complex method (delete+recreate flow) |
| miro/audit/memory.go | 9.68 | **10.0** | cc13 filter chain -> data-driven loop |
| miro/members.go | 9.68 | **10.0** | Complex method |
| miro/desirepath/logger.go | 9.68 | **10.0** | Complex method |
| miro/text.go | 9.68 | **10.0** | Complex method + style dedup |
| miro/oauth/auth.go | 9.68 | **10.0** | Login cc10 -> 3 phases |
| miro/embed.go | 9.68 | **10.0** | Complex method |

22 of 27 flagged files now at 10.0. Nine further files (shape, mermaid, sequence, cache, audit/factory, diagrams/errors, normalizers, errors, search) carry only file-level Primitive-Obsession / String-Heavy-Arguments findings whose fix requires typed-ID public signature changes across the test suite - out of scope for a behavior-preserving pass (details in the residuals note below).

## Residuals (deliberately not forced to 10.0)

- **upload.go 9.38, codewidgets.go 9.68**: file-level primitive/string-argument ratios on path- and ID-handling helpers; typed wrappers would be metric-chasing.
- **bulk.go 9.38**: BulkCreate/BulkUpdate remain structurally similar because their public result schemas genuinely differ (Created+ItemURLs vs Updated); merging them would change tool output.
- **groups.go 9.38**: "Overall Code Complexity" (mean cc over many small idiomatic API methods); further splitting would be degenerate.
- **share_allowlist.go 9.68**: 83% string arguments - the module's domain is emails/domains as strings.

## Badges

- Removed the dead Go Report Card badge.
- Added an HTML comment placeholder for a CodeScene Code Health badge (post-onboarding at codescene.io).
- No separate lint.yml was added: `ci.yml` already runs `golangci-lint-action@v9` in a dedicated `lint` job and its CI badge is already in the README, so a second workflow would double-run the linter and duplicate the badge. (The prior scan's "no workflow runs golangci-lint" premise was stale.)

## Verification

- `golangci-lint run ./...` -> 0 issues (v2.12.2, config already schema v2)
- `go test ./...` -> all 10 packages pass (834 test functions)
- Build green after every file touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)