### PR TITLE
chore: add lint status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Run your [Miro](https://miro.com) workshops, retros, and planning sessions from 
 **98 tools** | **Single binary** | **All platforms** | **All major AI tools**
 
 [![CI](https://github.com/olgasafonova/miro-mcp-server/actions/workflows/ci.yml/badge.svg)](https://github.com/olgasafonova/miro-mcp-server/actions/workflows/ci.yml)
+[![lint](https://github.com/olgasafonova/miro-mcp-server/actions/workflows/ci.yml/badge.svg?event=push)](https://github.com/olgasafonova/miro-mcp-server/actions/workflows/ci.yml)
 <!-- CodeScene Code Health badge: add after onboarding repo at codescene.io -->
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![MCP Context — full](badges/mcp-tokens.svg)](#token-efficiency)


### PR DESCRIPTION
Adds a lint status badge to the README badge cluster.

golangci-lint runs inside the existing `.github/workflows/ci.yml` (workflow name "CI"), so the badge honestly points at that workflow with `?event=push`:

`[![lint](https://github.com/olgasafonova/miro-mcp-server/actions/workflows/ci.yml/badge.svg?event=push)](https://github.com/olgasafonova/miro-mcp-server/actions/workflows/ci.yml)`

Matches the existing linked-badge style/placement. The CodeScene placeholder comment was well-formed and left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)