### PR TITLE
docs: add CodeScene Code Health badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Run your [Miro](https://miro.com) workshops, retros, and planning sessions from 
 
 [![CI](https://github.com/olgasafonova/miro-mcp-server/actions/workflows/ci.yml/badge.svg)](https://github.com/olgasafonova/miro-mcp-server/actions/workflows/ci.yml)
 [![lint](https://github.com/olgasafonova/miro-mcp-server/actions/workflows/ci.yml/badge.svg?event=push)](https://github.com/olgasafonova/miro-mcp-server/actions/workflows/ci.yml)
-<!-- CodeScene Code Health badge: add after onboarding repo at codescene.io -->
+[![CodeScene Average Code Health](https://codescene.io/projects/82990/status-badges/average-code-health)](https://codescene.io/projects/82990)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![MCP Context — full](badges/mcp-tokens.svg)](#token-efficiency)
 [![MCP Context — essentials](badges/mcp-tokens-essentials.svg)](#token-efficiency)


### PR DESCRIPTION
Adds the CodeScene Average Code Health badge (currently **9.84**, Green) to the README, replacing the placeholder comment. Test files are excluded from the CodeScene analysis, so this reflects shippable source health.

🤖 Generated with [Claude Code](https://claude.com/claude-code)