### PR TITLE
ci: dedicated lint.yml so the lint badge reads 'lint'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,29 +45,6 @@ jobs:
           files: coverage.out
           fail_ci_if_error: false
 
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
-
-      - name: Set up Go
-        uses: actions/setup-go@v7
-        with:
-          go-version: '1.25'
-          cache: true
-
-      - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v9
-        with:
-          version: v2.7.2
-          args: --timeout=5m
-          # Skip `golangci-lint config verify`, which fetches a JSON schema
-          # from golangci-lint.run at runtime and intermittently fails the job
-          # with "context deadline exceeded" when that host is slow/unreachable.
-          # The config is already validated by the lint run itself.
-          verify: false
-
   build:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,34 @@
+name: lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  golangci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version: '1.25'
+          cache: true
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.7.2
+          args: --timeout=5m
+          # Skip `golangci-lint config verify`, which fetches a JSON schema
+          # from golangci-lint.run at runtime and intermittently fails the job
+          # with "context deadline exceeded" when that host is slow/unreachable.
+          # The config is already validated by the lint run itself.
+          verify: false

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Run your [Miro](https://miro.com) workshops, retros, and planning sessions from 
 **98 tools** | **Single binary** | **All platforms** | **All major AI tools**
 
 [![CI](https://github.com/olgasafonova/miro-mcp-server/actions/workflows/ci.yml/badge.svg)](https://github.com/olgasafonova/miro-mcp-server/actions/workflows/ci.yml)
-[![lint](https://github.com/olgasafonova/miro-mcp-server/actions/workflows/ci.yml/badge.svg?event=push)](https://github.com/olgasafonova/miro-mcp-server/actions/workflows/ci.yml)
+[![lint](https://github.com/olgasafonova/miro-mcp-server/actions/workflows/lint.yml/badge.svg)](https://github.com/olgasafonova/miro-mcp-server/actions/workflows/lint.yml)
 [![CodeScene Average Code Health](https://codescene.io/projects/82990/status-badges/average-code-health)](https://codescene.io/projects/82990)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![MCP Context — full](badges/mcp-tokens.svg)](#token-efficiency)


### PR DESCRIPTION
The lint badge previously pointed at `ci.yml`, which GitHub renders as "CI" — producing two identical "CI passing" badges. This moves golangci-lint into a dedicated `lint.yml` (name: `lint`) so the badge reads **lint passing**, and removes the lint job from `ci.yml` so it no longer runs twice per push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)