### PR TITLE
docs: bust stale lint badge cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Run your [Miro](https://miro.com) workshops, retros, and planning sessions from 
 **98 tools** | **Single binary** | **All platforms** | **All major AI tools**
 
 [![CI](https://github.com/olgasafonova/miro-mcp-server/actions/workflows/ci.yml/badge.svg)](https://github.com/olgasafonova/miro-mcp-server/actions/workflows/ci.yml)
-[![lint](https://github.com/olgasafonova/miro-mcp-server/actions/workflows/lint.yml/badge.svg)](https://github.com/olgasafonova/miro-mcp-server/actions/workflows/lint.yml)
+[![lint](https://github.com/olgasafonova/miro-mcp-server/actions/workflows/lint.yml/badge.svg?branch=main)](https://github.com/olgasafonova/miro-mcp-server/actions/workflows/lint.yml)
 [![CodeScene Average Code Health](https://codescene.io/projects/82990/status-badges/average-code-health)](https://codescene.io/projects/82990)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![MCP Context — full](badges/mcp-tokens.svg)](#token-efficiency)


### PR DESCRIPTION
Adds `?branch=main` to the lint badge URL so GitHub's image proxy re-fetches a fresh image instead of serving the stale 'no status' one cached during the workflow's first run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)