### PR TITLE
docs: refresh stale MCP context token badges (15K->17.2K)

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,14 +159,14 @@ The MCP Apps pattern is TypeScript-only today (Go SDK has no `ext-apps` helpers)
 
 ## Token Efficiency
 
-The full tool surface (98 tools) costs roughly **16.5K tokens** of preload — about 8.3% of a 200K Claude context. For sessions where that footprint matters, set `MIRO_TOOLS_PROFILE=essentials` in your client config; the server then registers a curated 15-tool subset (boards, list/find/search, sticky/text/frame/connector creation, list/get/update/delete items) plus one discovery meta-tool. Agents reach the rest via `miro_tool_search` on demand.
+The full tool surface (98 tools) costs roughly **17.2K tokens** of preload — about 8.6% of a 200K Claude context. For sessions where that footprint matters, set `MIRO_TOOLS_PROFILE=essentials` in your client config; the server then registers a curated 15-tool subset (boards, list/find/search, sticky/text/frame/connector creation, list/get/update/delete items) plus one discovery meta-tool. Agents reach the rest via `miro_tool_search` on demand.
 
 | Profile | Tools | Preload tokens (est.) | % of 200K context |
 |---|---|---|---|
-| `full` (default) | 98 | ~16,500 | 8.3% |
-| `essentials` | 15 | ~2,400 | 1.2% |
+| `full` (default) | 98 | ~17,240 | 8.6% |
+| `essentials` | 15 | ~2,570 | 1.3% |
 
-Savings: **~13,100 tokens (84.5% reduction)** when you opt into `essentials`. Description tokens are exact (JSON-marshaled); schema cost is estimated at 200 bytes per tool. Reproduce locally with `go run ./cmd/token-count/`.
+Savings: **~14,700 tokens (85.1% reduction)** when you opt into `essentials`. Description tokens are exact (JSON-marshaled); schema cost is estimated at 200 bytes per tool. Reproduce locally with `go run ./cmd/token-count/`.
 
 `miro_tool_search(query?, category?, limit?)` is registered in both profiles. It searches tool names, titles, descriptions, and categories with weighted keyword scoring (name 3×, title 2×, category 2.5×, description 1×), returns up to 50 matches, and never recommends itself. Use it when you don't know which tool to reach for, or to scope to a category before browsing. Empty query plus a category returns the category's tools alphabetically.
 

--- a/badges/mcp-tokens-essentials.svg
+++ b/badges/mcp-tokens-essentials.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="306" height="20" role="img" aria-label="MCP Context (essentials): ~2K tokens (1.2%)">
-  <title>MCP Context (essentials): ~2K tokens (1.2%)</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="306" height="20" role="img" aria-label="MCP Context (essentials): ~2K tokens (1.3%)">
+  <title>MCP Context (essentials): ~2K tokens (1.3%)</title>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
     <stop offset="1" stop-opacity=".1"/>
@@ -15,7 +15,7 @@
   <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="11">
     <text aria-hidden="true" x="88.0" y="15" fill="#010101" fill-opacity=".3">MCP Context (essentials)</text>
     <text x="88.0" y="14">MCP Context (essentials)</text>
-    <text aria-hidden="true" x="241.2" y="15" fill="#010101" fill-opacity=".3">~2K tokens (1.2%)</text>
-    <text x="241.2" y="14">~2K tokens (1.2%)</text>
+    <text aria-hidden="true" x="241.2" y="15" fill="#010101" fill-opacity=".3">~2K tokens (1.3%)</text>
+    <text x="241.2" y="14">~2K tokens (1.3%)</text>
   </g>
 </svg>

--- a/badges/mcp-tokens.svg
+++ b/badges/mcp-tokens.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="228" height="20" role="img" aria-label="MCP Context: ~15K tokens (7.8%)">
-  <title>MCP Context: ~15K tokens (7.8%)</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="228" height="20" role="img" aria-label="MCP Context: ~17K tokens (8.6%)">
+  <title>MCP Context: ~17K tokens (8.6%)</title>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
     <stop offset="1" stop-opacity=".1"/>
@@ -15,7 +15,7 @@
   <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="11">
     <text aria-hidden="true" x="45.8" y="15" fill="#010101" fill-opacity=".3">MCP Context</text>
     <text x="45.8" y="14">MCP Context</text>
-    <text aria-hidden="true" x="160.0" y="15" fill="#010101" fill-opacity=".3">~15K tokens (7.8%)</text>
-    <text x="160.0" y="14">~15K tokens (7.8%)</text>
+    <text aria-hidden="true" x="160.0" y="15" fill="#010101" fill-opacity=".3">~17K tokens (8.6%)</text>
+    <text x="160.0" y="14">~17K tokens (8.6%)</text>
   </g>
 </svg>


### PR DESCRIPTION
The MCP context token badges were stale — they read ~15K/7.8%, the README prose said 16.5K/8.3%, and the actual current tool surface is **17,236 tokens / 8.6%** (98 tools; the count grew after tool-search/profiles landed in #42, but nobody re-ran the generator).

Regenerated the SVGs via `go run ./cmd/token-count/` and synced the README table + prose so badge, text, and generator all agree.

Note: the `% of 200K` baseline is unchanged — 200K is still Claude's standard context tier and is stated explicitly in the section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)