### PR TITLE
chore(beads): upgrade hook shim v1.0.3 -> v1.1.2

### DIFF
--- a/.beads/hooks/post-checkout
+++ b/.beads/hooks/post-checkout
@@ -1,19 +1,28 @@
 #!/usr/bin/env sh
-# --- BEGIN BEADS INTEGRATION v1.0.0 ---
+# --- BEGIN BEADS INTEGRATION v1.1.2 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
   _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
+  _bd_used_perl=0
   if command -v timeout >/dev/null 2>&1; then
     timeout "$_bd_timeout" bd hooks run post-checkout "$@"
     _bd_exit=$?
-    if [ $_bd_exit -eq 124 ]; then
-      echo >&2 "beads: hook 'post-checkout' timed out after ${_bd_timeout}s — continuing without beads"
-      _bd_exit=0
-    fi
+  elif command -v gtimeout >/dev/null 2>&1; then
+    gtimeout "$_bd_timeout" bd hooks run post-checkout "$@"
+    _bd_exit=$?
+  elif command -v perl >/dev/null 2>&1; then
+    _bd_used_perl=1
+    perl -e 'alarm shift; exec @ARGV' "$_bd_timeout" bd hooks run post-checkout "$@"
+    _bd_exit=$?
   else
+    echo >&2 "beads: hook 'post-checkout' running without timeout; install coreutils or perl to enable BEADS_HOOK_TIMEOUT"
     bd hooks run post-checkout "$@"
     _bd_exit=$?
+  fi
+  if [ $_bd_exit -eq 124 ] || { [ $_bd_used_perl -eq 1 ] && [ $_bd_exit -eq 142 ]; }; then
+    echo >&2 "beads: hook 'post-checkout' timed out after ${_bd_timeout}s — continuing without beads"
+    _bd_exit=0
   fi
   if [ $_bd_exit -eq 3 ]; then
     echo >&2 "beads: database not initialized — skipping hook 'post-checkout'"
@@ -21,4 +30,4 @@ if command -v bd >/dev/null 2>&1; then
   fi
   if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
 fi
-# --- END BEADS INTEGRATION v1.0.0 ---
+# --- END BEADS INTEGRATION v1.1.2 ---

--- a/.beads/hooks/post-merge
+++ b/.beads/hooks/post-merge
@@ -1,19 +1,28 @@
 #!/usr/bin/env sh
-# --- BEGIN BEADS INTEGRATION v1.0.0 ---
+# --- BEGIN BEADS INTEGRATION v1.1.2 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
   _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
+  _bd_used_perl=0
   if command -v timeout >/dev/null 2>&1; then
     timeout "$_bd_timeout" bd hooks run post-merge "$@"
     _bd_exit=$?
-    if [ $_bd_exit -eq 124 ]; then
-      echo >&2 "beads: hook 'post-merge' timed out after ${_bd_timeout}s — continuing without beads"
-      _bd_exit=0
-    fi
+  elif command -v gtimeout >/dev/null 2>&1; then
+    gtimeout "$_bd_timeout" bd hooks run post-merge "$@"
+    _bd_exit=$?
+  elif command -v perl >/dev/null 2>&1; then
+    _bd_used_perl=1
+    perl -e 'alarm shift; exec @ARGV' "$_bd_timeout" bd hooks run post-merge "$@"
+    _bd_exit=$?
   else
+    echo >&2 "beads: hook 'post-merge' running without timeout; install coreutils or perl to enable BEADS_HOOK_TIMEOUT"
     bd hooks run post-merge "$@"
     _bd_exit=$?
+  fi
+  if [ $_bd_exit -eq 124 ] || { [ $_bd_used_perl -eq 1 ] && [ $_bd_exit -eq 142 ]; }; then
+    echo >&2 "beads: hook 'post-merge' timed out after ${_bd_timeout}s — continuing without beads"
+    _bd_exit=0
   fi
   if [ $_bd_exit -eq 3 ]; then
     echo >&2 "beads: database not initialized — skipping hook 'post-merge'"
@@ -21,4 +30,4 @@ if command -v bd >/dev/null 2>&1; then
   fi
   if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
 fi
-# --- END BEADS INTEGRATION v1.0.0 ---
+# --- END BEADS INTEGRATION v1.1.2 ---

--- a/.beads/hooks/pre-commit
+++ b/.beads/hooks/pre-commit
@@ -1,19 +1,28 @@
 #!/usr/bin/env sh
-# --- BEGIN BEADS INTEGRATION v1.0.0 ---
+# --- BEGIN BEADS INTEGRATION v1.1.2 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
   _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
+  _bd_used_perl=0
   if command -v timeout >/dev/null 2>&1; then
     timeout "$_bd_timeout" bd hooks run pre-commit "$@"
     _bd_exit=$?
-    if [ $_bd_exit -eq 124 ]; then
-      echo >&2 "beads: hook 'pre-commit' timed out after ${_bd_timeout}s — continuing without beads"
-      _bd_exit=0
-    fi
+  elif command -v gtimeout >/dev/null 2>&1; then
+    gtimeout "$_bd_timeout" bd hooks run pre-commit "$@"
+    _bd_exit=$?
+  elif command -v perl >/dev/null 2>&1; then
+    _bd_used_perl=1
+    perl -e 'alarm shift; exec @ARGV' "$_bd_timeout" bd hooks run pre-commit "$@"
+    _bd_exit=$?
   else
+    echo >&2 "beads: hook 'pre-commit' running without timeout; install coreutils or perl to enable BEADS_HOOK_TIMEOUT"
     bd hooks run pre-commit "$@"
     _bd_exit=$?
+  fi
+  if [ $_bd_exit -eq 124 ] || { [ $_bd_used_perl -eq 1 ] && [ $_bd_exit -eq 142 ]; }; then
+    echo >&2 "beads: hook 'pre-commit' timed out after ${_bd_timeout}s — continuing without beads"
+    _bd_exit=0
   fi
   if [ $_bd_exit -eq 3 ]; then
     echo >&2 "beads: database not initialized — skipping hook 'pre-commit'"
@@ -21,4 +30,4 @@ if command -v bd >/dev/null 2>&1; then
   fi
   if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
 fi
-# --- END BEADS INTEGRATION v1.0.0 ---
+# --- END BEADS INTEGRATION v1.1.2 ---

--- a/.beads/hooks/pre-push
+++ b/.beads/hooks/pre-push
@@ -1,19 +1,28 @@
 #!/usr/bin/env sh
-# --- BEGIN BEADS INTEGRATION v1.0.0 ---
+# --- BEGIN BEADS INTEGRATION v1.1.2 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
   _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
+  _bd_used_perl=0
   if command -v timeout >/dev/null 2>&1; then
     timeout "$_bd_timeout" bd hooks run pre-push "$@"
     _bd_exit=$?
-    if [ $_bd_exit -eq 124 ]; then
-      echo >&2 "beads: hook 'pre-push' timed out after ${_bd_timeout}s — continuing without beads"
-      _bd_exit=0
-    fi
+  elif command -v gtimeout >/dev/null 2>&1; then
+    gtimeout "$_bd_timeout" bd hooks run pre-push "$@"
+    _bd_exit=$?
+  elif command -v perl >/dev/null 2>&1; then
+    _bd_used_perl=1
+    perl -e 'alarm shift; exec @ARGV' "$_bd_timeout" bd hooks run pre-push "$@"
+    _bd_exit=$?
   else
+    echo >&2 "beads: hook 'pre-push' running without timeout; install coreutils or perl to enable BEADS_HOOK_TIMEOUT"
     bd hooks run pre-push "$@"
     _bd_exit=$?
+  fi
+  if [ $_bd_exit -eq 124 ] || { [ $_bd_used_perl -eq 1 ] && [ $_bd_exit -eq 142 ]; }; then
+    echo >&2 "beads: hook 'pre-push' timed out after ${_bd_timeout}s — continuing without beads"
+    _bd_exit=0
   fi
   if [ $_bd_exit -eq 3 ]; then
     echo >&2 "beads: database not initialized — skipping hook 'pre-push'"
@@ -21,4 +30,4 @@ if command -v bd >/dev/null 2>&1; then
   fi
   if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
 fi
-# --- END BEADS INTEGRATION v1.0.0 ---
+# --- END BEADS INTEGRATION v1.1.2 ---

--- a/.beads/hooks/prepare-commit-msg
+++ b/.beads/hooks/prepare-commit-msg
@@ -1,19 +1,28 @@
 #!/usr/bin/env sh
-# --- BEGIN BEADS INTEGRATION v1.0.0 ---
+# --- BEGIN BEADS INTEGRATION v1.1.2 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then
   export BD_GIT_HOOK=1
   _bd_timeout=${BEADS_HOOK_TIMEOUT:-300}
+  _bd_used_perl=0
   if command -v timeout >/dev/null 2>&1; then
     timeout "$_bd_timeout" bd hooks run prepare-commit-msg "$@"
     _bd_exit=$?
-    if [ $_bd_exit -eq 124 ]; then
-      echo >&2 "beads: hook 'prepare-commit-msg' timed out after ${_bd_timeout}s — continuing without beads"
-      _bd_exit=0
-    fi
+  elif command -v gtimeout >/dev/null 2>&1; then
+    gtimeout "$_bd_timeout" bd hooks run prepare-commit-msg "$@"
+    _bd_exit=$?
+  elif command -v perl >/dev/null 2>&1; then
+    _bd_used_perl=1
+    perl -e 'alarm shift; exec @ARGV' "$_bd_timeout" bd hooks run prepare-commit-msg "$@"
+    _bd_exit=$?
   else
+    echo >&2 "beads: hook 'prepare-commit-msg' running without timeout; install coreutils or perl to enable BEADS_HOOK_TIMEOUT"
     bd hooks run prepare-commit-msg "$@"
     _bd_exit=$?
+  fi
+  if [ $_bd_exit -eq 124 ] || { [ $_bd_used_perl -eq 1 ] && [ $_bd_exit -eq 142 ]; }; then
+    echo >&2 "beads: hook 'prepare-commit-msg' timed out after ${_bd_timeout}s — continuing without beads"
+    _bd_exit=0
   fi
   if [ $_bd_exit -eq 3 ]; then
     echo >&2 "beads: database not initialized — skipping hook 'prepare-commit-msg'"
@@ -21,4 +30,4 @@ if command -v bd >/dev/null 2>&1; then
   fi
   if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
 fi
-# --- END BEADS INTEGRATION v1.0.0 ---
+# --- END BEADS INTEGRATION v1.1.2 ---


### PR DESCRIPTION
The v1.0.3 shim guards `bd hooks run` by branching **solely on `timeout`**. Neither `timeout` nor `gtimeout` exists on this machine — only `/usr/bin/perl` — so it fell through to an **unguarded call**. A hung `bd` would block commits indefinitely.

The perl-alarm fallback first appears in v1.1.0:

```
perl -e 'alarm shift; exec @ARGV' 300 bd hooks run pre-commit
```

Also picks up the exit-3 "DB not initialized" soft-skip.

**The distinction that caused this to go unnoticed:** `bd` the *binary* auto-upgrades, but hook shims are **generated files written to disk at install time** and do not update with it. This repo was running bd 1.1.2 while executing a shim written by bd 1.0.3.

Four repos were in that state (this one, `claude-code-config`, `public360-mcp-server`, `skillcheck`). All regenerated via `bd hooks install --beads`.

**One note specific to this repo:** it had *both* a `.beads/hooks` set (v1.0.0, 27-04 12:41) and a `.git/hooks` set (v1.0.3, 27-04 16:00), with `core.hooksPath` unset — so the newer generation was the one git actually ran. Timestamps suggest a `--beads` install followed 3.5h later by a plain `bd hooks install` that wrote to the default target and left the config unset. This PR sets `hooksPath` and brings `.beads/hooks` to v1.1.2. The now-shadowed `.git/hooks` files are untracked and inert; they were left in place deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)