### PR TITLE
chore(deps): bump go-sdk to v1.7.0 for MCP 2026-07-28

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,13 @@ go 1.25.0
 
 require (
 	github.com/google/uuid v1.6.0
-	github.com/modelcontextprotocol/go-sdk v1.6.1
+	github.com/modelcontextprotocol/go-sdk v1.7.0
 	github.com/olgasafonova/mcp-otel-go v0.1.0
+)
+
+require (
+	golang.org/x/sync v0.20.0 // indirect
+	golang.org/x/time v0.15.0 // indirect
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -15,8 +15,8 @@ github.com/google/jsonschema-go v0.4.3 h1:/DBOLZTfDow7pe2GmaJNhltueGTtDKICi8V8p+
 github.com/google/jsonschema-go v0.4.3/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/modelcontextprotocol/go-sdk v1.6.1 h1:0zOSupjKUxPKSocPT1Wtago+mUHU2/uZ4xSOY0FGReU=
-github.com/modelcontextprotocol/go-sdk v1.6.1/go.mod h1:kzm3kzFL1/+AziGOE0nUs3gvPoNxMCvkxokMkuFapXQ=
+github.com/modelcontextprotocol/go-sdk v1.7.0 h1:yqjY2dsbKAC0LSuWZVBMrHgiG8ukXv6NRo0JiALay44=
+github.com/modelcontextprotocol/go-sdk v1.7.0/go.mod h1:dL7u98E/zjJTGzEq+j30jQ8K2k1mb6LeAH4inEcSGts=
 github.com/olgasafonova/mcp-otel-go v0.1.0 h1:kETTTdsD+iXswjWnZfnUDU9BeqNSlwhHXAGdEyECm6Y=
 github.com/olgasafonova/mcp-otel-go v0.1.0/go.mod h1:AOexKB1BUZ8YYFybd1ZJd7ZntOKNziux+97E7gNUWT8=
 github.com/olgasafonova/mcp-servercard-go v0.3.0 h1:v2ptLFSSw0434nBZp5yI4Ya1xHajUE8gy2etkKQ531Y=
@@ -45,8 +45,12 @@ go.opentelemetry.io/otel/trace v1.43.0 h1:BkNrHpup+4k4w+ZZ86CZoHHEkohws8AY+WTX09
 go.opentelemetry.io/otel/trace v1.43.0/go.mod h1:/QJhyVBUUswCphDVxq+8mld+AvhXZLhe+8WVFxiFff0=
 golang.org/x/oauth2 v0.35.0 h1:Mv2mzuHuZuY2+bkyWXIHMfhNdJAdwW3FuWeCPYN5GVQ=
 golang.org/x/oauth2 v0.35.0/go.mod h1:lzm5WQJQwKZ3nwavOZ3IS5Aulzxi68dUSgRHujetwEA=
+golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
+golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
 golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/time v0.15.0 h1:bbrp8t3bGUeFOx08pvsMYRTCVSMk89u4tKbNOZbp88U=
+golang.org/x/time v0.15.0/go.mod h1:Y4YMaQmXwGQZoFaVFk4YpCt4FLQMYKZe9oeV/f4MSno=
 golang.org/x/tools v0.42.0 h1:uNgphsn75Tdz5Ji2q36v/nsFSfR/9BRFvqhGBaJGd5k=
 golang.org/x/tools v0.42.0/go.mod h1:Ma6lCIwGZvHK6XtgbswSoWroEkhugApmsXyrUmBhfr0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
Bumps `modelcontextprotocol/go-sdk` from v1.6.1 to v1.7.0, which adds support for MCP protocol revision **`2026-07-28`** (released 28-07-2026).

## What the revision changes

- `initialize` / `notifications/initialized` handshake removed. Each request carries its protocol version, client info, and capabilities in `_meta` (SEP-2575).
- New `server/discover` RPC that servers MUST implement.
- Protocol-level sessions and `Mcp-Session-Id` removed from Streamable HTTP (SEP-2567).
- Server-initiated requests (roots, sampling, elicitation) replaced by Multi Round-Trip Requests: the server returns `resultType: "input_required"` and the client retries with answers (SEP-2322).
- `ping`, `logging/setLevel`, `resources/subscribe` removed; `subscriptions/listen` replaces free-floating notifications.
- Roots, sampling, and logging formally deprecated under a new twelve-month deprecation window.

## Why this is safe

Backward compatibility is preserved on every endpoint and the SDK negotiates the highest mutually supported version at connect time. Legacy clients continue to negotiate `2025-11-25` unchanged. This server uses none of the deprecated features (no MCP roots, sampling, or logging anywhere in the tree), so the deprecation clock does not apply to it.

## Verification

Run on the branch before committing:

```
go build ./...              OK
go test ./...               OK
golangci-lint run ./...     OK
```

Functional smoke test over stdio against the rebuilt binary:

- Legacy `initialize` still negotiates `protocolVersion=2025-11-25`.
- `server/discover` with `_meta."io.modelcontextprotocol/protocolVersion": "2026-07-28"` returns `resultType: complete`, confirming the new revision is live.
- Without that `_meta`, `server/discover` correctly returns `-32601` (SDK PR #1084 rejects discover from pre-`2026-07-28` requests).

## Note on the diff

`go mod tidy` is required, not just `go get`. v1.7.0 adds two transitive dependencies: `golang.org/x/sync/errgroup` (MRTR) and `golang.org/x/time/rate` (logging rate limiting). Without the tidy the build fails on missing `go.sum` entries.

## Behaviour changes carried by the SDK upgrade

These land even on the old protocol revision:

- `ToolAnnotations.ReadOnlyHint` and `IdempotentHint` are now always serialized rather than omitted when false.
- Resource-not-found moved from `-32002` to `-32602`.
- `MethodNotFound` now includes its code in stdio error responses.
- Invalid params are wrapped as `-32602`.

v1.7.0 ships seven `MCPGODEBUG` escape hatches to restore the old behaviour. **They are deliberately not used here**, since all of them are removed in v1.9.0.

## Follow-ups, not in this PR

- **Stateless Streamable HTTP.** This server calls `NewStreamableHTTPHandler(fn, nil)`, so it stays stateful and will negotiate every HTTP client down to `2025-11-25`. Serving `2026-07-28` over HTTP requires `&mcp.StreamableHTTPOptions{Stateless: true}`. Low risk here since one shared `*mcp.Server` is already returned per request, but it changes session-id handling (ignored) and `DELETE` (405), so it belongs in its own PR.
- Adopting `ttlMs` on list results. The SDK sets `cacheScope: "public"` but leaves `ttlMs: 0`, meaning every list response is marked immediately stale, and there is no `ServerOptions` knob for it. Needs receiving middleware.
- `x-mcp-header` passthrough and the standard `Mcp-Method` / `Mcp-Name` headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
