### PR TITLE
ci: bump pinned golangci-lint to v2.12.2

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.7.2
+          version: v2.12.2
           args: --timeout=5m
           # Skip `golangci-lint config verify`, which fetches a JSON schema
           # from golangci-lint.run at runtime and intermittently fails the job


### PR DESCRIPTION
Bumps the pinned `golangci-lint` from **v2.7.2** to **v2.12.2**.

## The finding

v2.7.2 reports six `SA5011` "possible nil pointer dereference" errors in pre-existing test files. Every one is a false positive:

```go
if toolSelection == nil { t.Fatal(...) }   // terminal — nothing continues
total := len(toolSelection.Tests)          // flagged as possible nil deref
```

`SA5011` only fires here if the analyzer fails to model `(*testing.T).Fatal` as non-returning.

## Why the version is the cause

Proven inside `nordic-registry-mcp-server`, which pinned two different versions at once:

| Workflow | Pinned | Result on the same commit |
|---|---|---|
| `lint.yml` | v2.12.2 | passed |
| `ci.yml` | v2.7.2 | failed with the six findings |

Same commit, same runner, same `.golangci.yml`, same Go toolchain. The only difference was the linter version.

That also settles a discrepancy worth recording: the failure does **not** reproduce locally. I matched the pinned v2.7.2, the repo's own config, the exact CI invocation (`run --timeout=5m`), `GOTOOLCHAIN=go1.25.12`, the toolchain the linter binary was *compiled* with, a cold `GOLANGCI_LINT_CACHE`, and `GOOS=linux GOARCH=amd64`. Every combination reported `0 issues`. Anyone chasing this locally should not expect to see it.

## Context

This gate blocked the Wave 1 stateless-HTTP PRs (miro #89, nordic-registry #53), which were merged with `--admin`, leaving `main` red on both repos. This PR is what turns them green again.

Nothing in the Go source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
