### PR TITLE
feat(cache): advertise a 30-minute ttlMs alongside the OTel middleware

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 require (
 	github.com/google/uuid v1.6.0
 	github.com/modelcontextprotocol/go-sdk v1.7.0
+	github.com/olgasafonova/mcp-cache-go v0.1.0
 	github.com/olgasafonova/mcp-otel-go v0.1.0
 )
 
@@ -23,10 +24,9 @@ require (
 	github.com/segmentio/encoding v0.5.4 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
-	go.opentelemetry.io/otel v1.43.0 // indirect
+	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/metric v1.43.0 // indirect
-	go.opentelemetry.io/otel/sdk v1.43.0 // indirect
-	go.opentelemetry.io/otel/sdk/metric v1.43.0 // indirect
+	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	golang.org/x/oauth2 v0.35.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,8 @@ github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/modelcontextprotocol/go-sdk v1.7.0 h1:yqjY2dsbKAC0LSuWZVBMrHgiG8ukXv6NRo0JiALay44=
 github.com/modelcontextprotocol/go-sdk v1.7.0/go.mod h1:dL7u98E/zjJTGzEq+j30jQ8K2k1mb6LeAH4inEcSGts=
+github.com/olgasafonova/mcp-cache-go v0.1.0 h1:JAyn1obQG4he5WJLqSp3bjblKMF9lXVuOc3lgW2NsLs=
+github.com/olgasafonova/mcp-cache-go v0.1.0/go.mod h1:3eVVOwpy3vE7CV4nCSAmbJlBYYADst1Rf+cc0ByMN/A=
 github.com/olgasafonova/mcp-otel-go v0.1.0 h1:kETTTdsD+iXswjWnZfnUDU9BeqNSlwhHXAGdEyECm6Y=
 github.com/olgasafonova/mcp-otel-go v0.1.0/go.mod h1:AOexKB1BUZ8YYFybd1ZJd7ZntOKNziux+97E7gNUWT8=
 github.com/olgasafonova/mcp-servercard-go v0.3.0 h1:v2ptLFSSw0434nBZp5yI4Ya1xHajUE8gy2etkKQ531Y=
@@ -43,6 +45,8 @@ go.opentelemetry.io/otel/sdk/metric v1.43.0 h1:S88dyqXjJkuBNLeMcVPRFXpRw2fuwdvfC
 go.opentelemetry.io/otel/sdk/metric v1.43.0/go.mod h1:C/RJtwSEJ5hzTiUz5pXF1kILHStzb9zFlIEe85bhj6A=
 go.opentelemetry.io/otel/trace v1.43.0 h1:BkNrHpup+4k4w+ZZ86CZoHHEkohws8AY+WTX09nk+3A=
 go.opentelemetry.io/otel/trace v1.43.0/go.mod h1:/QJhyVBUUswCphDVxq+8mld+AvhXZLhe+8WVFxiFff0=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 golang.org/x/oauth2 v0.35.0 h1:Mv2mzuHuZuY2+bkyWXIHMfhNdJAdwW3FuWeCPYN5GVQ=
 golang.org/x/oauth2 v0.35.0/go.mod h1:lzm5WQJQwKZ3nwavOZ3IS5Aulzxi68dUSgRHujetwEA=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/olgasafonova/mcp-cache-go/mcpcache"
 	"github.com/olgasafonova/mcp-otel-go/mcpotel"
 	"github.com/olgasafonova/mcp-servercard-go/servercard"
 	"github.com/olgasafonova/miro-mcp-server/miro"
@@ -178,9 +179,13 @@ func initAuditLogger(logger *slog.Logger) audit.Logger {
 	return auditLogger
 }
 
-// createMCPServer constructs the MCP server with OTel middleware attached.
-// Capabilities is set explicitly to suppress pre-initialize tools/list_changed
-// notifications from go-sdk, which can break the initialize handshake.
+// createMCPServer constructs the MCP server with OTel and cache-TTL middleware
+// attached. Capabilities is set explicitly to suppress pre-initialize
+// tools/list_changed notifications from go-sdk.
+//
+// Attached here rather than in runStdioServer or the HTTP handler because main
+// builds one *mcp.Server and hands it to whichever transport is selected.
+// Attaching in a transport branch would leave the other one unstamped.
 func createMCPServer(logger *slog.Logger) *mcp.Server {
 	server := mcp.NewServer(&mcp.Implementation{
 		Name:    ServerName,
@@ -191,10 +196,35 @@ func createMCPServer(logger *slog.Logger) *mcp.Server {
 		Capabilities: &mcp.ServerCapabilities{Tools: &mcp.ToolCapabilities{}},
 	})
 
-	server.AddReceivingMiddleware(mcpotel.Middleware(mcpotel.Config{
-		ServiceName:    ServerName,
-		ServiceVersion: ServerVersion,
-	}))
+	// Both middlewares go in ONE call, and the order is deliberate.
+	//
+	// AddReceivingMiddleware applies right-to-left, so this composes as
+	// mcpotel(mcpcache(handler)): OTel is outermost. Its span therefore covers
+	// the TTL stamp as well as the handler.
+	//
+	// Two separate calls would NOT do this. Each call wraps whatever handler is
+	// already installed (shared.go:113), so adding mcpcache in a second call
+	// would compose as mcpcache(mcpotel(handler)) and stamp the TTL after the
+	// OTel span had already ended. Harmless today, because mcpotel never reads
+	// ttlMs, but it is the wrong nesting to leave in place.
+	//
+	// mcpcache: SEP-2549 requires ttlMs and cacheScope on every cacheable
+	// result, but the SDK's setDefaultCacheableValues() sets cacheScope only and
+	// leaves ttlMs at 0, which the spec reads as "immediately stale". There is
+	// no ServerOptions knob for it. Thirty minutes because this is an actively
+	// developed surface; the tool set changes when a release ships.
+	server.AddReceivingMiddleware(
+		mcpotel.Middleware(mcpotel.Config{
+			ServiceName:    ServerName,
+			ServiceVersion: ServerVersion,
+		}),
+		mcpcache.Middleware(mcpcache.Config{
+			TTLs: map[string]time.Duration{
+				mcpcache.MethodListTools: 30 * time.Minute,
+				mcpcache.MethodDiscover:  30 * time.Minute,
+			},
+		}),
+	)
 
 	return server
 }

--- a/main_cache_test.go
+++ b/main_cache_test.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+// TestCreateMCPServer_BothMiddlewaresFire pins that createMCPServer attaches
+// BOTH receiving middlewares and that neither displaces the other.
+//
+// This server is the only one in the portfolio running two receiving
+// middlewares, so it is the only place the composition can break. The two
+// assertions fail independently:
+//
+//   - drop mcpcache from the AddReceivingMiddleware call and the ttlMs
+//     assertion fails with "ttlMs = 0, want 1800000"
+//   - drop mcpotel and the span assertion fails with "no OTel span recorded"
+//
+// Both were run. An assertion on the config alone would pass with either
+// middleware unwired, which is the whole failure mode.
+//
+// Driven through buildHTTPMux rather than an in-memory stdio session because
+// this server serves both transports from one *mcp.Server; a stdio-only
+// assertion would pass while the HTTP path went unstamped.
+func TestCreateMCPServer_BothMiddlewaresFire(t *testing.T) {
+	// mcpotel resolves otel.GetTracerProvider() when Middleware() is
+	// constructed, which happens inside createMCPServer. The global must
+	// therefore be swapped BEFORE testHTTPOpts builds the server.
+	exporter := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		otel.SetTracerProvider(prev)
+		_ = tp.Shutdown(t.Context())
+	})
+
+	mux := buildHTTPMux(testHTTPOpts(t, ""))
+
+	body, err := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "tools/list",
+		"params": map[string]any{"_meta": map[string]any{
+			"io.modelcontextprotocol/protocolVersion":    "2026-07-28",
+			"io.modelcontextprotocol/clientInfo":         map[string]any{"name": "test", "version": "1"},
+			"io.modelcontextprotocol/clientCapabilities": map[string]any{},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("marshalling request: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(string(body)))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	req.Header.Set("Mcp-Protocol-Version", "2026-07-28")
+	req.Header.Set("Mcp-Method", "tools/list")
+
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rec.Code, rec.Body.String())
+	}
+
+	// mcpcache fired: the result advertises a real TTL rather than the SDK's 0.
+	const wantTTL = 1800000 // thirty minutes, matching createMCPServer
+	if got := extractTTLMs(t, rec.Body.String()); got != wantTTL {
+		t.Errorf("ttlMs = %d, want %d", got, wantTTL)
+	}
+
+	// mcpotel fired: a server span was recorded for the same call.
+	if !hasSpanForMethod(exporter.GetSpans(), "tools/list") {
+		t.Error("no OTel span recorded for tools/list; mcpotel middleware did not fire")
+	}
+}
+
+// hasSpanForMethod reports whether any exported span carries the mcp.method.name
+// attribute for the given method. Matching on the attribute rather than the span
+// name keeps this independent of mcpotel's span-naming scheme.
+func hasSpanForMethod(spans tracetest.SpanStubs, method string) bool {
+	for _, s := range spans {
+		for _, attr := range s.Attributes {
+			if string(attr.Key) == "mcp.method.name" && attr.Value.AsString() == method {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// extractTTLMs pulls ttlMs off a tools/list response. The handler may answer as
+// plain JSON or as an SSE frame depending on the Accept header, so scan for the
+// data payload rather than assuming one shape.
+func extractTTLMs(t *testing.T, raw string) int {
+	t.Helper()
+
+	for _, line := range strings.Split(raw, "\n") {
+		line = strings.TrimPrefix(strings.TrimSpace(line), "data: ")
+		if !strings.HasPrefix(line, "{") {
+			continue
+		}
+		var envelope struct {
+			Result struct {
+				TTLMs *int `json:"ttlMs"`
+			} `json:"result"`
+		}
+		if err := json.Unmarshal([]byte(line), &envelope); err != nil {
+			continue
+		}
+		if envelope.Result.TTLMs != nil {
+			return *envelope.Result.TTLMs
+		}
+	}
+
+	t.Fatalf("no ttlMs field found in response: %s", raw)
+	return 0
+}


### PR DESCRIPTION
Final leg of bead `claude-code-config-4fc4.2`. Completes the sweep: **7 of 7 servers** now advertise a real `ttlMs`. Prior legs: gleif #62, ratatoskr #22, ridge #46, nordic-registry #55, mediawiki #109, public360 #44.

## Why

SEP-2549 requires `ttlMs` and `cacheScope` on every cacheable result. The SDK's `setDefaultCacheableValues()` sets `cacheScope` only and leaves `ttlMs` at `0`, which the spec reads as *immediately stale* — so a compliant client caches nothing and re-fetches the tool list every turn. With 98 tools that is the largest wasted payload in the portfolio. There is no `ServerOptions` knob, so `AddReceivingMiddleware` is the only way to stamp one.

## The composition, which is the actual content of this PR

miro is the only server already running a receiving middleware (`mcpotel`), so it is the only place this can break. Both now go in **one** `AddReceivingMiddleware` call:

```go
server.AddReceivingMiddleware(
    mcpotel.Middleware(...),
    mcpcache.Middleware(...),
)
```

The call applies right-to-left, so this composes as `mcpotel(mcpcache(handler))` — OTel outermost, its span covering the TTL stamp as well as the handler.

**Two separate calls would not do this.** Each call wraps whatever handler is already installed (`go-sdk shared.go:113`), so adding `mcpcache` in a second call composes as `mcpcache(mcpotel(handler))` and stamps the TTL *after* the OTel span has ended. Harmless today because `mcpotel` never reads `ttlMs`, but the wrong nesting to leave in place for whatever is added next.

Attached in `createMCPServer`, not a transport branch: `main` builds one `*mcp.Server` and hands it to either the HTTP handler or stdio.

## Verification

`TestCreateMCPServer_BothMiddlewaresFire` drives `buildHTTPMux` (not an in-memory stdio session — this server serves both transports, and a stdio-only assertion would pass while the HTTP path went unstamped) and asserts both middlewares independently.

**Double ablation, both run and confirmed:**

| Removed | Failure |
|---|---|
| `mcpcache` | `ttlMs = 0, want 1800000` |
| `mcpotel` | `no OTel span recorded for tools/list; mcpotel middleware did not fire` |

A config-only assertion would pass with either middleware unwired, which is the whole failure mode.

`make check` green (fmt-check + vet + lint + test). `go mod tidy` run and idempotent; `mcp-cache-go` and `otel/sdk` recorded as direct dependencies.

Live-binary probe over `mcp.CommandTransport` to follow after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)