### PR TITLE
fix(ci): diff go.mod as well as go.sum in the tidy check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,12 +22,12 @@ jobs:
       - name: Verify dependencies
         run: go mod verify
 
-      - name: Check go.sum integrity
+      - name: Check go.mod and go.sum integrity
         run: |
           go mod tidy
-          if ! git diff --quiet go.sum; then
-            echo "::error::go.sum is not up to date. Run 'go mod tidy' and commit the changes."
-            git diff go.sum
+          if ! git diff --quiet go.mod go.sum; then
+            echo "::error::go.mod or go.sum is not up to date. Run 'go mod tidy' and commit the changes."
+            git diff go.mod go.sum
             exit 1
           fi
 


### PR DESCRIPTION
The tidy check runs `go mod tidy` and then diffs `go.sum` only. The `// indirect` drift it exists to catch lives in **`go.mod`**, so it reported clean on exactly that failure.

Cause: running `go get` *before* adding the import records the module as `// indirect` in `go.mod`, and adding the import later does not clear the annotation. `go build`, `go test -race` and `golangci-lint` all pass either way, so no local gate can see it. Only `go mod tidy` normalizes it, and it rewrites `go.mod` alone.

## Reproduced before fixing

Committed the drift on a throwaway worktree (marking the direct `go-sdk` require as `// indirect`), then ran what CI runs:

| step | result |
|---|---|
| `go build ./...` | passes, so local gates are blind |
| `go mod tidy` | rewrites `go.mod` only (`1 file changed, 1 insertion(+), 1 deletion(-)`) |
| `git diff --quiet go.sum` (before) | **passes** — drift not caught |
| `git diff --quiet go.mod go.sum` (after) | **fails** — drift caught |

## Context

This drift reddened ratatoskr #22 and ridge #46 on 30-07-2026. `ratatoskr/.github/workflows/ci.yml:46` already had the correct two-file form; a portfolio audit found three repos on the weak form (this one, plus the other two getting the identical patch) and five already correct.

`rules/mcp-server-patterns.md` "Supply Chain Security" was updated to mandate the two-file diff in commit `1203f36`; this is the code half. Bead `claude-code-config-sm7o`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)