### PR TITLE
fix(m00e): drop idempotentHint from miro_tool_search

### DIFF
--- a/tools/annotation_coherence_test.go
+++ b/tools/annotation_coherence_test.go
@@ -1,0 +1,25 @@
+package tools
+
+import "testing"
+
+// TestAnnotationCoherence guards against a read-only tool also declaring
+// idempotentHint. idempotentHint carries meaning only for tools that modify
+// state: a read-only tool is trivially repeatable, so asserting idempotence
+// on it says nothing and misleads a client reasoning about retry safety.
+//
+// This does not forbid Idempotent on its own. Most of the Idempotent specs in
+// this repo sit on write tools, where the hint is exactly the useful signal —
+// a repeated update converges, a repeated create does not.
+func TestAnnotationCoherence(t *testing.T) {
+	var incoherent []string
+	for _, spec := range AllTools {
+		if spec.ReadOnly && spec.Idempotent {
+			incoherent = append(incoherent, spec.Name)
+		}
+	}
+
+	if len(incoherent) > 0 {
+		t.Errorf("%d of %d specs set both ReadOnly and Idempotent; drop Idempotent on read-only specs: %v",
+			len(incoherent), len(AllTools), incoherent)
+	}
+}

--- a/tools/search.go
+++ b/tools/search.go
@@ -43,12 +43,11 @@ type ToolSearchResult struct {
 // than inlined into AllTools) so the registration site and the search
 // implementation stay close.
 var SearchToolSpec = ToolSpec{
-	Name:       ToolSearchName,
-	Method:     "SearchTools",
-	Title:      "Find Miro Tools",
-	Category:   "discovery",
-	ReadOnly:   true,
-	Idempotent: true,
+	Name:     ToolSearchName,
+	Method:   "SearchTools",
+	Title:    "Find Miro Tools",
+	Category: "discovery",
+	ReadOnly: true,
 	Description: `Find Miro tools by keyword or category. Returns matching tool names + short descriptions; call those tools directly afterward.
 
 USE WHEN: you don't know which tool exists for a task, or you want to scope to a category before browsing. Examples: "find tools for stickies", "what can I do with frames?", "show me all destructive tools".


### PR DESCRIPTION
Part of `claude-code-config-m00e` — 95 incoherent `readOnly`+`idempotent` specs across four repos. This is miro's 1, the smallest slice and the one that shows why the check has to test a conjunction rather than ban a hint.

## The defect

`SearchToolSpec` was the repo's only spec setting `ReadOnly` and `Idempotent` both true. `idempotentHint` only carries meaning for tools that modify state: a read-only tool is trivially repeatable, so declaring idempotence on it says nothing and misleads a client reasoning about retry safety.

## What is deliberately left alone

This repo has 17 other `Idempotent: true` specs. All sit on **write** tools, where the hint is exactly the useful signal — a repeated update converges where a repeated create does not. They are correct and untouched.

The new `TestAnnotationCoherence` therefore checks the `ReadOnly && Idempotent` conjunction. A test that simply banned the hint would have flagged 18 specs and been wrong about 17 of them.

The 43 specs setting neither field are also correct: they are create/update/delete/bulk operations, and `false`/`false` is the honest default.

## Verification

- Measured over `AllTools`: **1 of 98 incoherent before, 0 of 98 after.** The measurement doubles as the receipt that the other 17 are on non-read-only tools.
- `go build ./...`, `go test ./...`, `golangci-lint run ./...` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)