### PR TITLE
feat: x-mcp-header passthrough for board_id (SEP-2243)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
-	github.com/google/jsonschema-go v0.4.3 // indirect
+	github.com/google/jsonschema-go v0.4.3
 	github.com/olgasafonova/mcp-servercard-go v0.3.0
 	github.com/segmentio/asm v1.1.3 // indirect
 	github.com/segmentio/encoding v0.5.4 // indirect

--- a/main_test.go
+++ b/main_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/olgasafonova/miro-mcp-server/miro"
+	"github.com/olgasafonova/miro-mcp-server/tools"
 )
 
 // =============================================================================
@@ -533,4 +534,111 @@ func TestPrintOAuthSetupHelp(t *testing.T) {
 	if !strings.Contains(out, "miro.com") {
 		t.Errorf("setup help should link to the Miro app settings\n%s", out)
 	}
+}
+
+// TestBuildHTTPMux_ParamHeaderPassthrough proves the x-mcp-header annotations
+// are live on the HTTP transport (SEP-2243), not merely present in a schema:
+// a tools/call whose annotated argument agrees with its Mcp-Param header
+// reaches the handler, and any disagreement — wrong value or missing header —
+// is rejected with -32020 HeaderMismatch before the handler runs. The
+// mismatch half is the proof: a malformed annotation is silently ignored by
+// the SDK, so only a rejection demonstrates the binding exists.
+func TestBuildHTTPMux_ParamHeaderPassthrough(t *testing.T) {
+	opts := testHTTPOpts(t, "")
+	// testHTTPOpts builds an empty server; the annotations live on registered
+	// tools, so register the full profile the way main does.
+	logger := quietLogger()
+	client := miro.NewClient(&miro.Config{AccessToken: "test-token"}, logger)
+	tools.NewHandlerRegistry(client, logger).RegisterProfile(opts.server, tools.ProfileFull)
+	mux := buildHTTPMux(opts)
+
+	newMeta := map[string]any{
+		"io.modelcontextprotocol/protocolVersion":    "2026-07-28",
+		"io.modelcontextprotocol/clientInfo":         map[string]any{"name": "test", "version": "1"},
+		"io.modelcontextprotocol/clientCapabilities": map[string]any{},
+	}
+
+	callBoard := func(t *testing.T, paramHeader string) *httptest.ResponseRecorder {
+		t.Helper()
+		body, err := json.Marshal(map[string]any{
+			"jsonrpc": "2.0",
+			"id":      1,
+			"method":  "tools/call",
+			"params": map[string]any{
+				"_meta":     newMeta,
+				"name":      "miro_get_board",
+				"arguments": map[string]any{"board_id": "board-123"},
+			},
+		})
+		if err != nil {
+			t.Fatalf("marshalling request: %v", err)
+		}
+		req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(string(body)))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Accept", "application/json, text/event-stream")
+		req.Header.Set("Mcp-Protocol-Version", "2026-07-28")
+		req.Header.Set("Mcp-Method", "tools/call")
+		req.Header.Set("Mcp-Name", "miro_get_board")
+		if paramHeader != "" {
+			req.Header.Set("Mcp-Param-Board-Id", paramHeader)
+		}
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+		return rec
+	}
+
+	t.Run("annotation is visible in tools/list", func(t *testing.T) {
+		body, err := json.Marshal(map[string]any{
+			"jsonrpc": "2.0",
+			"id":      1,
+			"method":  "tools/list",
+			"params":  map[string]any{"_meta": newMeta},
+		})
+		if err != nil {
+			t.Fatalf("marshalling request: %v", err)
+		}
+		req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(string(body)))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Accept", "application/json, text/event-stream")
+		req.Header.Set("Mcp-Protocol-Version", "2026-07-28")
+		req.Header.Set("Mcp-Method", "tools/list")
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, want 200; body = %s", rec.Code, rec.Body.String())
+		}
+		got := rec.Body.String()
+		if !strings.Contains(got, `"x-mcp-header":"Board-Id"`) {
+			t.Error("tools/list does not expose the x-mcp-header annotation")
+		}
+		// filterValidTools drops tools with malformed annotations; both
+		// annotated tools must still be listed.
+		for _, name := range []string{"miro_get_board", "miro_list_items"} {
+			if !strings.Contains(got, `"name":"`+name+`"`) {
+				t.Errorf("%s missing from tools/list — annotation rejected by the SDK?", name)
+			}
+		}
+	})
+
+	t.Run("agreeing header reaches the handler", func(t *testing.T) {
+		rec := callBoard(t, "board-123")
+		if got := rec.Body.String(); strings.Contains(got, "-32020") {
+			t.Errorf("agreeing body+header was rejected with HeaderMismatch: %s", got)
+		}
+	})
+
+	t.Run("disagreeing header is rejected with -32020", func(t *testing.T) {
+		rec := callBoard(t, "board-999")
+		if got := rec.Body.String(); !strings.Contains(got, "-32020") {
+			t.Errorf("disagreeing header was not rejected with HeaderMismatch: status=%d body=%s", rec.Code, got)
+		}
+	})
+
+	t.Run("missing header for a present annotated param is rejected with -32020", func(t *testing.T) {
+		rec := callBoard(t, "")
+		if got := rec.Body.String(); !strings.Contains(got, "-32020") {
+			t.Errorf("missing Mcp-Param-Board-Id was not rejected with HeaderMismatch: status=%d body=%s", rec.Code, got)
+		}
+	})
 }

--- a/tools/definitions.go
+++ b/tools/definitions.go
@@ -47,6 +47,19 @@ type ToolSpec struct {
 
 	// Idempotent indicates repeated calls have the same effect
 	Idempotent bool
+
+	// HeaderParams maps an input-schema property name to the Mcp-Param-*
+	// header suffix that mirrors it over Streamable HTTP (SEP-2243
+	// x-mcp-header). Example: {"board_id": "Board-Id"} declares that the
+	// board_id argument travels as the Mcp-Param-Board-Id header, letting an
+	// intermediary route or observe per-board traffic without reading the
+	// JSON-RPC body. Only primitive (string, integer, boolean) top-level
+	// properties are valid; registration panics on anything else because the
+	// SDK silently ignores malformed annotations. Enforcement is strict for
+	// clients negotiating >= 2026-07-28 over HTTP: when the annotated
+	// argument is present, the header must be present and agree, or the
+	// transport rejects the call with -32020 HeaderMismatch.
+	HeaderParams map[string]string
 }
 
 // AllTools contains all registered Miro MCP tools.
@@ -72,11 +85,12 @@ var AllTools = []ToolSpec{
 VOICE-FRIENDLY: "Found 5 boards: Design Sprint, Product Roadmap, Team Retro..."`,
 	},
 	{
-		Name:     "miro_get_board",
-		Method:   "GetBoard",
-		Title:    "Get Board Details",
-		Category: "boards",
-		ReadOnly: true,
+		Name:         "miro_get_board",
+		Method:       "GetBoard",
+		Title:        "Get Board Details",
+		Category:     "boards",
+		ReadOnly:     true,
+		HeaderParams: map[string]string{"board_id": "Board-Id"},
 		Description: `Get board metadata: name, description, owner, creation date, and sharing policy.
 
 USE WHEN: "who owns this board?", "when was this board created?", "board settings", "tell me about this board"
@@ -356,11 +370,12 @@ VOICE-FRIENDLY: "Deleted 5 items from the board"`,
 	// Read/List Tools
 	// ==========================================================================
 	{
-		Name:     "miro_list_items",
-		Method:   "ListItems",
-		Title:    "List Board Items",
-		Category: "read",
-		ReadOnly: true,
+		Name:         "miro_list_items",
+		Method:       "ListItems",
+		Title:        "List Board Items",
+		Category:     "read",
+		ReadOnly:     true,
+		HeaderParams: map[string]string{"board_id": "Board-Id"},
 		Description: `List items on a Miro board (max 50). For ALL items with auto-pagination, use miro_list_all_items. For text search, use miro_search_board.
 
 USE WHEN: "what's on the board", "show all stickies", "list shapes"`,

--- a/tools/handlers.go
+++ b/tools/handlers.go
@@ -9,6 +9,7 @@ import (
 	"runtime/debug"
 	"time"
 
+	"github.com/google/jsonschema-go/jsonschema"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/olgasafonova/miro-mcp-server/miro"
 	"github.com/olgasafonova/miro-mcp-server/miro/audit"
@@ -333,6 +334,39 @@ func (h *HandlerRegistry) buildTool(spec ToolSpec) *mcp.Tool {
 	}
 }
 
+// headerAnnotatedSchema infers the input schema for Args and attaches the
+// spec's x-mcp-header annotations (SEP-2243 per-parameter header
+// passthrough). The SDK only infers a schema when the tool does not provide
+// one, and jsonschema struct tags cannot carry arbitrary keywords, so tools
+// with HeaderParams pre-build their schema here and hand it to AddTool.
+//
+// It panics on an unknown or non-primitive property because the SDK's
+// annotation extraction silently skips malformed annotations — a wrong shape
+// would be indistinguishable from no annotation, and validateParamHeaderAnnotations
+// would drop the whole tool from tools/list over HTTP. Registration runs at
+// startup, so a panic here is a build-time programming error surfaced loudly,
+// matching AddTool's own panic-on-invalid behaviour.
+func headerAnnotatedSchema[Args any](spec ToolSpec) *jsonschema.Schema {
+	schema, err := jsonschema.For[Args](nil)
+	if err != nil {
+		panic(fmt.Sprintf("tool %s: inferring input schema: %v", spec.Name, err))
+	}
+	for prop, header := range spec.HeaderParams {
+		p, ok := schema.Properties[prop]
+		if !ok {
+			panic(fmt.Sprintf("tool %s: HeaderParams names unknown property %q", spec.Name, prop))
+		}
+		if p.Type != "string" && p.Type != "integer" && p.Type != "boolean" {
+			panic(fmt.Sprintf("tool %s: HeaderParams property %q has type %q; x-mcp-header allows only string, integer, boolean", spec.Name, prop, p.Type))
+		}
+		if p.Extra == nil {
+			p.Extra = map[string]any{}
+		}
+		p.Extra["x-mcp-header"] = header
+	}
+	return schema
+}
+
 // registerTool is a generic helper that registers a tool with the MCP server.
 //
 // The dispatcher closure uses NAMED return values so the deferred recoverPanic
@@ -347,6 +381,9 @@ func registerTool[Args, Result any](
 	spec ToolSpec,
 	method func(context.Context, Args) (Result, error),
 ) {
+	if len(spec.HeaderParams) > 0 {
+		tool.InputSchema = headerAnnotatedSchema[Args](spec)
+	}
 	mcp.AddTool(server, tool, func(ctx context.Context, req *mcp.CallToolRequest, args Args) (res *mcp.CallToolResult, out Result, err error) {
 		defer h.recoverPanic(spec.Name, &err)
 

--- a/tools/headerparams_test.go
+++ b/tools/headerparams_test.go
@@ -1,0 +1,124 @@
+package tools
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+type headerParamsTestArgs struct {
+	BoardID string `json:"board_id" jsonschema:"Board ID"`
+	Limit   int    `json:"limit,omitempty" jsonschema:"Max items"`
+	Filter  struct {
+		Kind string `json:"kind,omitempty"`
+	} `json:"filter,omitempty"`
+}
+
+// TestHeaderAnnotatedSchemaAttachesAnnotation: the returned schema carries the
+// x-mcp-header keyword on the named property, in the exact shape the SDK's
+// collectParamHeaderAnnotations reads (a plain string on the property object).
+func TestHeaderAnnotatedSchemaAttachesAnnotation(t *testing.T) {
+	spec := ToolSpec{
+		Name:         "test_tool",
+		HeaderParams: map[string]string{"board_id": "Board-Id"},
+	}
+
+	schema := headerAnnotatedSchema[headerParamsTestArgs](spec)
+
+	raw, err := json.Marshal(schema)
+	if err != nil {
+		t.Fatalf("marshaling schema: %v", err)
+	}
+	var decoded struct {
+		Properties map[string]map[string]any `json:"properties"`
+	}
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("unmarshaling schema: %v", err)
+	}
+
+	got, ok := decoded.Properties["board_id"]["x-mcp-header"]
+	if !ok {
+		t.Fatalf("board_id property has no x-mcp-header keyword:\n%s", raw)
+	}
+	if got != "Board-Id" {
+		t.Errorf("x-mcp-header = %v, want Board-Id", got)
+	}
+
+	// Un-annotated properties must stay clean.
+	if _, ok := decoded.Properties["limit"]["x-mcp-header"]; ok {
+		t.Error("limit property unexpectedly carries x-mcp-header")
+	}
+
+	// The rest of the inferred schema must survive: descriptions and types.
+	if decoded.Properties["board_id"]["description"] != "Board ID" {
+		t.Errorf("board_id description = %v, want the jsonschema tag value", decoded.Properties["board_id"]["description"])
+	}
+}
+
+// TestHeaderAnnotatedSchemaPanicsOnUnknownProperty: a HeaderParams entry that
+// names a property the Args struct does not have is a programming error and
+// must fail loudly at registration, because the SDK silently ignores
+// malformed annotations.
+func TestHeaderAnnotatedSchemaPanicsOnUnknownProperty(t *testing.T) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic for unknown property")
+		}
+		if !strings.Contains(r.(string), "unknown property") {
+			t.Errorf("panic %v does not mention unknown property", r)
+		}
+	}()
+	headerAnnotatedSchema[headerParamsTestArgs](ToolSpec{
+		Name:         "test_tool",
+		HeaderParams: map[string]string{"nope": "Nope"},
+	})
+}
+
+// TestHeaderAnnotatedSchemaPanicsOnNonPrimitive: x-mcp-header is only valid
+// on string/integer/boolean properties; an object property must be rejected
+// at registration rather than dropped from tools/list at serve time.
+func TestHeaderAnnotatedSchemaPanicsOnNonPrimitive(t *testing.T) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic for non-primitive property")
+		}
+		if !strings.Contains(r.(string), "only string, integer, boolean") {
+			t.Errorf("panic %v does not mention the allowed types", r)
+		}
+	}()
+	headerAnnotatedSchema[headerParamsTestArgs](ToolSpec{
+		Name:         "test_tool",
+		HeaderParams: map[string]string{"filter": "Filter"},
+	})
+}
+
+// TestAllToolsHeaderParamsAreWellFormed pins which tools declare header
+// passthrough and that every declared header suffix is a valid HTTP token, so
+// a typo fails here rather than being logged-and-dropped by the SDK's
+// tools/list filter.
+func TestAllToolsHeaderParamsAreWellFormed(t *testing.T) {
+	want := map[string]map[string]string{
+		"miro_get_board":  {"board_id": "Board-Id"},
+		"miro_list_items": {"board_id": "Board-Id"},
+	}
+
+	got := map[string]map[string]string{}
+	for _, spec := range AllTools {
+		if len(spec.HeaderParams) > 0 {
+			got[spec.Name] = spec.HeaderParams
+		}
+	}
+
+	if len(got) != len(want) {
+		t.Errorf("tools with HeaderParams = %v, want %v", got, want)
+	}
+	for name, params := range want {
+		for prop, header := range params {
+			if got[name][prop] != header {
+				t.Errorf("%s HeaderParams[%s] = %q, want %q", name, prop, got[name][prop], header)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Part of epic claude-code-config-4fc4 (bead 4fc4.3): per-parameter header passthrough on the HTTP transport, MCP 2026-07-28.

`miro_get_board` and `miro_list_items` declare `board_id` as the `Mcp-Param-Board-Id` header, letting an HTTP intermediary route or observe per-board traffic without reading the JSON-RPC body — the SEP-2243 pattern GitHub cited for their MCP server.

## Mechanism
The go-sdk implements the server side (`extractParamHeaderAnnotations`); the annotation just has to reach the input schema. `jsonschema:` struct tags cannot carry arbitrary keywords, so `ToolSpec` gains `HeaderParams` and registration pre-builds the schema via `jsonschema.For[Args]`, attaching the keyword through `Schema.Extra` before `AddTool` (a provided schema suppresses SDK inference).

Registration panics on an unknown or non-primitive property: the SDK silently skips malformed annotations and drops such tools from HTTP `tools/list`, so a wrong shape must fail loudly at startup instead of looking like no annotation.

## Verification
HTTP acceptance test (`TestBuildHTTPMux_ParamHeaderPassthrough`): agreeing body+header reaches the handler; disagreeing value **and** missing header are both rejected `-32020 HeaderMismatch`; the annotation is visible in `tools/list` at 2026-07-28 and neither annotated tool is dropped.

Note the enforcement semantics: for clients negotiating ≥ 2026-07-28 over HTTP, the header becomes mandatory whenever the annotated argument is present. Stdio (the local config) is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)