### PR TITLE
fix(security): loopback-bind bypass in isLoopbackAddr + constant-time bearer compare

### DIFF
--- a/http_test.go
+++ b/http_test.go
@@ -117,6 +117,24 @@ func TestIsLoopbackAddr(t *testing.T) {
 		{"0.0.0.0:8080", false},
 		{":8080", false},
 		{"192.168.1.10:8080", false},
+
+		// Regression: the previous implementation used
+		// strings.HasPrefix(addr, "localhost") / "127.0.0.1", so any hostname
+		// merely STARTING with either was read as loopback. That let
+		// validateHTTPSecurity skip the mandatory-token check and bind an
+		// externally-resolvable interface with no auth at all.
+		{"localhost.corp.example:8080", false},
+		{"localhost.evil.example:8080", false},
+		{"127.0.0.1.evil.example:8080", false},
+		{"localhostile:8080", false},
+
+		// Loopback forms that must keep working.
+		{"127.0.0.53:8080", true}, // all of 127.0.0.0/8 is loopback
+		{"[::1]:8080", true},      // IPv6 loopback
+		{"LOCALHOST:8080", true},  // host matching is case-insensitive
+		{"localhost", true},       // no port
+		{"127.0.0.1", true},       // no port
+		{"example.com:8080", false},
 	}
 
 	for _, tt := range tests {

--- a/main.go
+++ b/main.go
@@ -4,10 +4,12 @@ package main
 
 import (
 	"context"
+	"crypto/subtle"
 	"flag"
 	"fmt"
 	"log"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
@@ -357,8 +359,13 @@ func runStdioServer(server *mcp.Server, rt runtimeFlags) {
 func bearerTokenMiddleware(token string) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Constant-time compare: a plain != short-circuits on the first
+			// differing byte, which leaks the token prefix to a remote prober.
+			// mediawiki-mcp-server and nordic-registry-mcp-server both already
+			// use subtle.ConstantTimeCompare here; miro was the outlier.
 			auth := r.Header.Get("Authorization")
-			if auth == "" || auth != "Bearer "+token {
+			expected := "Bearer " + token
+			if auth == "" || subtle.ConstantTimeCompare([]byte(auth), []byte(expected)) != 1 {
 				w.Header().Set("WWW-Authenticate", `Bearer`)
 				http.Error(w, "Unauthorized", http.StatusUnauthorized)
 				return
@@ -478,10 +485,35 @@ func wrapNoStore(next http.Handler) http.Handler {
 
 // isLoopbackAddr reports whether addr binds only the local loopback interface.
 // A bare port (":8080") or "0.0.0.0" binds all interfaces and is treated as
-// externally reachable. IPv6 loopback is deliberately not special-cased: when
-// in doubt, the address is treated as external so authentication is required.
+// externally reachable. A hostname that is not exactly "localhost" and does not
+// parse as an IP is treated as non-loopback, which is the safe default.
+//
+// The host is parsed rather than prefix-matched. The previous implementation
+// used strings.HasPrefix(addr, "localhost"), which also matched hostnames that
+// merely START with it: "-http localhost.corp.example:8080" was read as a
+// loopback bind, so validateHTTPSecurity skipped the mandatory-token check and
+// the server could bind an externally-resolvable interface with no auth at all.
+// "127.0.0.1.evil.example" defeated the other prefix the same way. This is the
+// implementation mediawiki-mcp-server (isLoopbackBind) and
+// nordic-registry-mcp-server (isLoopbackAddr) already use; miro was the only
+// one of the three still on the prefix check.
 func isLoopbackAddr(addr string) bool {
-	return strings.HasPrefix(addr, "127.0.0.1") || strings.HasPrefix(addr, "localhost")
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		// No port present; treat the whole value as the host.
+		host = addr
+	}
+	host = strings.TrimSpace(host)
+	if host == "" {
+		return false
+	}
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		return ip.IsLoopback()
+	}
+	return false
 }
 
 // validateHTTPSecurity refuses to start an externally-reachable HTTP server that


### PR DESCRIPTION
Found auditing the three HTTP-exposed MCP servers against the cross-tenant session-replay class (`claude-code-config-vohf`).

## The bypass

`isLoopbackAddr` prefix-matched instead of parsing the host:

```go
return strings.HasPrefix(addr, "127.0.0.1") || strings.HasPrefix(addr, "localhost")
```

So any hostname *starting with* either string read as a loopback bind:

| `-http` value | old | correct |
|---|---|---|
| `localhost.corp.example:8080` | loopback | **not** loopback |
| `127.0.0.1.evil.example:8080` | loopback | **not** loopback |
| `localhostile:8080` | loopback | **not** loopback |

`validateHTTPSecurity` treats a loopback bind as safe and skips the mandatory-token check, so those inputs let the server bind an externally-resolvable interface **with no authentication at all** — walking straight past the guard that exists to prevent it.

Now uses `net.SplitHostPort` + exact case-insensitive `localhost` + `net.IP.IsLoopback`. That also fixes two false negatives: `127.0.0.53` (all of 127/8 is loopback) and IPv6 `[::1]`.

**This is drift, not a new design.** `mediawiki-mcp-server` (`isLoopbackBind`) and `nordic-registry-mcp-server` (`isLoopbackAddr`) already do it this way; miro was the only one of the three still prefix-matching.

## Bearer compare

`auth != "Bearer "+token` short-circuits on the first differing byte, leaking the token prefix to a remote prober. Switched to `subtle.ConstantTimeCompare`, matching the other two servers.

## Scope

Neither defect is cross-tenant session replay. This server has one process-wide Miro credential and no per-caller identity, so there are no tenants to cross; the caller's `Authorization` is an inbound gate only and is never propagated upstream.

Severity is also bounded by deployment: the MCP config runs this over stdio, and the Dockerfile has no `-http`. The bypass needs someone to pass `-http` with such a hostname. Worth fixing because the guard is load-bearing the moment HTTP is used.

## Verification

- `gofmt`, `go vet`, `golangci-lint`: clean
- `go test -race -failfast ./...`: 11 packages ok
- 11 new loopback cases, **mutation-verified**: reverting to the prefix check fails 7 of them, including all four bypass hostnames