### PR TITLE
feat: org audit log tool + native bulk create (1rq, 1vn)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`miro_bulk_create` now issues one request instead of one per item.** It called the typed single-create endpoint N times in parallel; it now posts to Miro's native `POST /v2/boards/{board_id}/items/bulk`. `MaxBulkItems` was already 20, the endpoint's own cap, so every request this server accepts fits in a single call — 20 stickies cost 1 request rather than 20, which is the rate-limit pressure the change is for.
+
+  The endpoint is **transactional**: if one item fails, none are created. That conflicts with this server's per-item contract, where 19 of 20 may land, so the fallback is deliberately narrow. A `400` means the batch was rejected on validation, and transactionality proves nothing was created — so it falls back to the old per-item fan-out, which cannot double-create and is the only way to report *which* item was bad. Any other failure (429, 5xx, network, timeout) leaves the outcome unknown, because the transaction may have committed with the response lost; there it does **not** fall back, and reports every item failed and retriable with a message saying the outcome is not provable. Falling back on those would be the bug that duplicates a whole batch.
+
+  Item bodies are built by the same helpers the typed `Create*` methods use, so a bulk-created item is byte-identical to a singly-created one. That matters most for sticky notes, whose fill colours are a named enum the API rejects hex for; a hand-rolled bulk mapping is exactly where that would drift. `buildStickyCreateBody` was extracted from `CreateSticky` for this, guarded by the existing sticky tests.
+
 - **`miro_get_audit_log`'s description now says which audit log it means.** It reads this server's local execution log, not Miro's — a distinction the name alone does not carry, and one that got easier to trip over now that both exist. Both descriptions name the other tool. The name itself is unchanged; renaming it would break existing callers for a problem that sharper wording fixes.
 
 - **README account-compatibility table corrected.** It claimed every plan had "full access to all tools", which was already untrue for the three PDF/SVG export tools and would now also be untrue for the org audit log. It now gives 102 tools on Free/Team/Business and names the four Enterprise-only tools. `miro_get_board_picture` works on every plan and is not one of them.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`miro_get_org_audit_logs` (1)**: wraps Miro's organization audit log, `GET /v2/audit/logs` — who did what across the Miro workspace, including actions taken outside this server. Enterprise plan and the `auditlogs:read` scope; 403 and 404 carry a hint saying so, because on this endpoint a non-Enterprise org, a missing scope, and a genuinely absent resource are indistinguishable from the status alone. A 400 deliberately does not get the hint: that is what a malformed time window returns, and a plan hint would send the caller after the wrong problem.
+
+  `created_after` and `created_before` are both required and validated locally, since the API has no default window and answers a missing bound with an opaque 400. The nested `context` object is flattened, so `team_id`, `team_name`, `organization_id` and `ip` sit directly on each event rather than making callers walk it. Miro retains 90 days; older events are only available via the CSV export in the admin UI, which this does not wrap. Tool count: 105 → 106.
+
+### Changed
+
+- **`miro_get_audit_log`'s description now says which audit log it means.** It reads this server's local execution log, not Miro's — a distinction the name alone does not carry, and one that got easier to trip over now that both exist. Both descriptions name the other tool. The name itself is unchanged; renaming it would break existing callers for a problem that sharper wording fixes.
+
+- **README account-compatibility table corrected.** It claimed every plan had "full access to all tools", which was already untrue for the three PDF/SVG export tools and would now also be untrue for the org audit log. It now gives 102 tools on Free/Team/Business and names the four Enterprise-only tools. `miro_get_board_picture` works on every plan and is not one of them.
+
 ### Fixed
 
 - **A client that omits `params` on `notifications/initialized` no longer crashes the server.** MCP makes `params` optional on notifications, so this was a plain interop crash: a spec-compliant client sending `{"jsonrpc":"2.0","method":"notifications/initialized"}` took the process down with a SIGSEGV before it could answer anything else. Sending `params:{}` avoided it, which is why it went unnoticed — the Go SDK's own client always populates the field.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # Miro MCP Server
 
 ## Project
-Go MCP server for Miro REST API v2. 105 tools across boards, items, diagrams, mindmaps, code widgets, comments, canvas SVG, tags, groups, connectors, export, and audit. OAuth2 + token auth. Single binary with stdio + HTTP transport.
+Go MCP server for Miro REST API v2. 106 tools across boards, items, diagrams, mindmaps, code widgets, comments, canvas SVG, tags, groups, connectors, export, and audit. OAuth2 + token auth. Single binary with stdio + HTTP transport.
 
 ## Architecture
 - `main.go` — entry point, dual stdio/HTTP transport, health/metrics endpoints, token validation
@@ -26,7 +26,7 @@ Go MCP server for Miro REST API v2. 105 tools across boards, items, diagrams, mi
 - All API methods live on the `MiroClient` interface for testability (mock in `tools/mock_client_test.go`)
 - Mermaid diagrams parsed locally (no external service), supporting flowchart + sequenceDiagram
 
-## Tool Categories (105 total)
+## Tool Categories (106 total)
 - **Board Management** (9): list, find, get, create, copy, update, delete, summary, content
 - **Board Members** (5): list, get, share, update, remove
 - **Create Items** (15): sticky, shape, flowchart shape, text, connector, frame, card, app card, image, document, embed, bulk create/update/delete, sticky grid
@@ -46,7 +46,7 @@ Go MCP server for Miro REST API v2. 105 tools across boards, items, diagrams, mi
 - **App Cards** (2): update, delete (create and get counted above)
 - **Export** (4): board picture, create job, status, results
 - **Diagrams** (1): generate from Mermaid
-- **Audit** (1): query local execution log
+- **Audit** (2): query local execution log, query Miro org audit log (Enterprise)
 - **Desire Paths** (1): report tool usage patterns
 
 ## Build & Test

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Run your [Miro](https://miro.com) workshops, retros, and planning sessions from 
 
 > **Community project** — Not officially affiliated with Miro. See [official options](#official-vs-community) below.
 
-**105 tools** | **Single binary** | **All platforms** | **All major AI tools**
+**106 tools** | **Single binary** | **All platforms** | **All major AI tools**
 
 [![CI](https://github.com/olgasafonova/miro-mcp-server/actions/workflows/ci.yml/badge.svg)](https://github.com/olgasafonova/miro-mcp-server/actions/workflows/ci.yml)
 [![lint](https://github.com/olgasafonova/miro-mcp-server/actions/workflows/lint.yml/badge.svg?branch=main)](https://github.com/olgasafonova/miro-mcp-server/actions/workflows/lint.yml)
@@ -146,7 +146,7 @@ go install github.com/olgasafonova/miro-cli/cmd/miro-cli@latest
 
 ## Companion MCP Apps server: `miro-mcp-apps`
 
-If you want Miro data to render as interactive **UI** in the chat (cards, tables, color clusters, SVG graphs) instead of streamed JSON, there's a TypeScript sibling: [`miro-mcp-apps`](https://github.com/olgasafonova/miro-mcp-apps). Six tools built on the [MCP Apps extension](https://github.com/modelcontextprotocol/ext-apps) (SEP-1865), reusing the same `MIRO_ACCESS_TOKEN`. The two servers run side-by-side: this one for the 105-tool CRUD surface, that one for visual at-a-glance views.
+If you want Miro data to render as interactive **UI** in the chat (cards, tables, color clusters, SVG graphs) instead of streamed JSON, there's a TypeScript sibling: [`miro-mcp-apps`](https://github.com/olgasafonova/miro-mcp-apps). Six tools built on the [MCP Apps extension](https://github.com/modelcontextprotocol/ext-apps) (SEP-1865), reusing the same `MIRO_ACCESS_TOKEN`. The two servers run side-by-side: this one for the 106-tool CRUD surface, that one for visual at-a-glance views.
 
 | You want… | Use |
 |---|---|
@@ -160,11 +160,11 @@ The MCP Apps pattern is TypeScript-only today (Go SDK has no `ext-apps` helpers)
 
 ## Token Efficiency
 
-The full tool surface (105 tools) costs roughly **19K tokens** of preload; the `essentials` profile trims that to ~2.7K. For sessions where that footprint matters, set `MIRO_TOOLS_PROFILE=essentials` in your client config; the server then registers a curated 15-tool subset (boards, list/find/search, sticky/text/frame/connector creation, list/get/update/delete items) plus one discovery meta-tool. Agents reach the rest via `miro_tool_search` on demand.
+The full tool surface (106 tools) costs roughly **19K tokens** of preload; the `essentials` profile trims that to ~2.7K. For sessions where that footprint matters, set `MIRO_TOOLS_PROFILE=essentials` in your client config; the server then registers a curated 15-tool subset (boards, list/find/search, sticky/text/frame/connector creation, list/get/update/delete items) plus one discovery meta-tool. Agents reach the rest via `miro_tool_search` on demand.
 
 | Profile | Tools | Preload tokens (est.) |
 |---|---|---|
-| `full` (default) | 105 | ~19,027 |
+| `full` (default) | 106 | ~19,317 |
 | `essentials` | 15 | ~2,719 |
 
 Savings: **~16,300 tokens (85.7% reduction)** when you opt into `essentials`. Description tokens are exact (JSON-marshaled); schema cost is estimated at 200 bytes per tool. Reproduce locally with `go run ./cmd/token-count/`.
@@ -175,7 +175,7 @@ See [CONFIG.md](CONFIG.md) for the full env-var reference.
 
 ---
 
-## All 105 Tools
+## All 106 Tools
 
 <details>
 <summary><b>Board Management (9)</b></summary>
@@ -401,12 +401,13 @@ See [CONFIG.md](CONFIG.md) for the full env-var reference.
 </details>
 
 <details>
-<summary><b>Diagrams & Audit (3)</b></summary>
+<summary><b>Diagrams & Audit (4)</b></summary>
 
 | Tool | Description |
 |------|-------------|
 | `miro_generate_diagram` | Create diagram from Mermaid syntax |
-| `miro_get_audit_log` | Query local execution log |
+| `miro_get_audit_log` | Query THIS SERVER's local execution log |
+| `miro_get_org_audit_logs` | Query MIRO's org-wide audit log (Enterprise; `auditlogs:read`) |
 | `miro_get_desire_paths` | Query agent normalization patterns (what agents sent vs. what got auto-corrected) |
 
 </details>
@@ -458,7 +459,7 @@ Miro released their [official MCP server](https://miro.com/ai/mcp/) in December 
 
 | Feature | This Server | Official Miro MCP |
 |---------|-------------|-------------------|
-| **Tools** | 105 (or 15 in `essentials` profile) | 65 |
+| **Tools** | 106 (or 15 in `essentials` profile) | 65 |
 | **Transport** | stdio + HTTP | HTTPS only (hosted at mcp.miro.com) |
 | **Self-hosting** | Yes | No |
 | **Offline mode** | Yes | No |
@@ -496,7 +497,7 @@ Board context is a design difference rather than a gap. `context_get` returns a 
 
 **When to use the official server:** You want zero-setup via plugin marketplace, OAuth 2.1 enterprise security, spaces and sections, comments, board context extraction, or SVG/prototype workflows.
 
-**When to use this server:** You need full REST coverage (105 tools, or a tunable 15-tool `essentials` mode), offline/self-hosted operation, richer board listing metadata, bulk ops, mindmaps, tags, connectors, or export.
+**When to use this server:** You need full REST coverage (106 tools, or a tunable 15-tool `essentials` mode), offline/self-hosted operation, richer board listing metadata, bulk ops, mindmaps, tags, connectors, or export.
 
 Both can coexist — use different MCP server names in your config.
 
@@ -601,7 +602,7 @@ MIRO_ACCESS_TOKEN=your-token npx @modelcontextprotocol/inspector miro-mcp-server
 ```
 
 Open `http://localhost:6274` to:
-- Browse all 105 tools with their schemas
+- Browse all 106 tools with their schemas
 - Test tool calls interactively
 - View raw JSON-RPC messages
 - Debug parameter validation
@@ -643,12 +644,14 @@ See [SETUP.md](SETUP.md) for configuration guides.
 
 | Account Type | Support |
 |--------------|---------|
-| Free | Full access to all 105 tools |
-| Team | Full access to all 105 tools |
-| Business | Full access to all 105 tools |
-| Enterprise | Full access + export to PDF/SVG |
+| Free | 102 tools |
+| Team | 102 tools |
+| Business | 102 tools |
+| Enterprise | All 106 tools |
 
-The 6 code widget tools use Miro's v2-experimental API; availability may vary by account or plan, and the endpoints may change before GA.
+Four tools need an Enterprise plan and fail with a hint saying so: the three PDF/SVG export tools (`miro_create_export_job`, `miro_get_export_job_status`, `miro_get_export_job_results`) and `miro_get_org_audit_logs`, which additionally needs the `auditlogs:read` scope. `miro_get_board_picture` works on every plan. Everything else works on any plan.
+
+The 6 code widget tools and 5 comment tools use Miro's v2-experimental API; availability may vary by account or plan, and the endpoints may change before GA.
 
 ---
 

--- a/badges/mcp-tokens.svg
+++ b/badges/mcp-tokens.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="222" height="20" role="img" aria-label="MCP context: 2.7K–19.0K tokens">
-  <title>MCP context: 2.7K–19.0K tokens</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="222" height="20" role="img" aria-label="MCP context: 2.7K–19.3K tokens">
+  <title>MCP context: 2.7K–19.3K tokens</title>
   <linearGradient id="s" x2="0" y2="100%">
     <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
     <stop offset="1" stop-opacity=".1"/>
@@ -15,7 +15,7 @@
   <g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="11">
     <text aria-hidden="true" x="45.8" y="15" fill="#010101" fill-opacity=".3">MCP context</text>
     <text x="45.8" y="14">MCP context</text>
-    <text aria-hidden="true" x="156.8" y="15" fill="#010101" fill-opacity=".3">2.7K–19.0K tokens</text>
-    <text x="156.8" y="14">2.7K–19.0K tokens</text>
+    <text aria-hidden="true" x="156.8" y="15" fill="#010101" fill-opacity=".3">2.7K–19.3K tokens</text>
+    <text x="156.8" y="14">2.7K–19.3K tokens</text>
   </g>
 </svg>

--- a/miro/bulk.go
+++ b/miro/bulk.go
@@ -357,13 +357,50 @@ func runBulkOp[T any](
 }
 
 // BulkCreate creates multiple items in one operation.
-// Items are created in parallel using goroutines, with concurrency
-// controlled by the client's semaphore (MaxConcurrentRequests).
+//
+// Tries Miro's native bulk endpoint first: one request for up to 20 items
+// instead of one per item. Falls back to the per-item fan-out only when the API
+// rejects the batch on validation, which its own transactionality proves
+// created nothing — see bulk_native.go for why the fallback is that narrow.
 func (c *Client) BulkCreate(ctx context.Context, args BulkCreateArgs) (BulkCreateResult, error) {
 	if err := validateBulkSize(args.BoardID, len(args.Items), "item"); err != nil {
 		return BulkCreateResult{}, err
 	}
 
+	ids, err := c.createItemsNative(ctx, args.BoardID, args.Items)
+	switch {
+	case err == nil:
+		c.cache.InvalidatePrefix("items:" + args.BoardID)
+		return BulkCreateResult{
+			Created:  len(ids),
+			ItemIDs:  ids,
+			ItemURLs: BuildItemURLs(args.BoardID, ids),
+			Message:  formatBulkMessage("Created", len(ids), len(args.Items), 0),
+		}, nil
+
+	case nativeBulkRejectedBatch(err) || isLocalMappingError(err):
+		// Nothing was created, so re-running per item is safe and is the only
+		// way to tell the caller WHICH item was bad.
+
+	default:
+		// 429, 5xx, network, timeout: the outcome is unknown and a fan-out here
+		// could duplicate every item.
+		return allItemsFailed(args.Items, err), nil
+	}
+
+	return c.bulkCreateFanOut(ctx, args)
+}
+
+// isLocalMappingError reports whether the native path failed before any request
+// was made, which likewise means nothing was created.
+func isLocalMappingError(err error) bool {
+	var apiErr *APIError
+	return !errors.As(err, &apiErr)
+}
+
+// bulkCreateFanOut is the original per-item path: one request per item, in
+// parallel, with per-item success and failure reporting.
+func (c *Client) bulkCreateFanOut(ctx context.Context, args BulkCreateArgs) (BulkCreateResult, error) {
 	agg := runBulkOp(ctx, args.Items,
 		func(ctx context.Context, _ int, item BulkCreateItem) (string, error) {
 			return createBulkItem(ctx, c, args.BoardID, item)

--- a/miro/bulk_native.go
+++ b/miro/bulk_native.go
@@ -1,0 +1,228 @@
+package miro
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+)
+
+// =============================================================================
+// Native Bulk Create (POST /v2/boards/{board_id}/items/bulk)
+// =============================================================================
+//
+// Replaces the per-item fan-out with ONE request for up to 20 items. MaxBulkItems
+// is already 20, the endpoint's own cap, so no chunking is needed: every request
+// this server accepts fits in a single call.
+//
+// The endpoint is TRANSACTIONAL — "if any item's create operation fails, the
+// create operation for all the remaining items also fails, and none of the items
+// will be created." That conflicts with this server's per-item contract
+// (Created/Errors/FailedItems/RetriableIDs), where 19 of 20 may land. The
+// reconciliation, and the reason this is safe:
+//
+//   - happy path: one request instead of N
+//   - a 400 means the batch was rejected on validation, and transactionality
+//     guarantees NOTHING was created, so falling back to the fan-out cannot
+//     double-create. The caller gets the same per-item detail as before, having
+//     spent one extra request to find out which item was bad.
+//   - any OTHER failure (429, 5xx, network, timeout) leaves the outcome UNKNOWN:
+//     the transaction may have committed with the response lost. Falling back
+//     there could duplicate every item, so it does not fall back. The items are
+//     reported failed-and-retriable, which is the same signal the fan-out would
+//     have produced and leaves the retry decision with the caller.
+//
+// Note the asymmetry is deliberate: fall back only where the API's own
+// transactionality proves nothing landed.
+
+// bulkCreateItemBody maps one BulkCreateItem onto the native wire body.
+//
+// Each type reuses the SAME builder as its typed Create* method rather than
+// re-deriving the mapping. That is what keeps a bulk-created sticky identical to
+// a singly-created one — in particular the sticky colour vocabulary, which is a
+// named-value enum the API rejects hex for.
+func bulkCreateItemBody(boardID string, item BulkCreateItem) (map[string]interface{}, error) {
+	var (
+		body map[string]interface{}
+		err  error
+	)
+
+	switch item.Type {
+	case "sticky_note":
+		if item.Content == "" {
+			return nil, errors.New("content is required")
+		}
+		body = buildStickyCreateBody(CreateStickyArgs{
+			BoardID:  boardID,
+			Content:  item.Content,
+			X:        item.X,
+			Y:        item.Y,
+			Color:    item.Color,
+			Width:    item.Width,
+			ParentID: item.ParentID,
+		})
+
+	case "shape":
+		shapeArgs := CreateShapeArgs{
+			BoardID:           boardID,
+			Shape:             item.Shape,
+			Content:           item.Content,
+			X:                 item.X,
+			Y:                 item.Y,
+			Width:             item.Width,
+			Height:            item.Height,
+			Color:             item.Color,
+			TextColor:         item.TextColor,
+			TextAlign:         item.TextAlign,
+			TextAlignVertical: item.TextAlignVertical,
+			FontSize:          item.FontSize,
+			ParentID:          item.ParentID,
+		}
+		if err := validateShapeCreateArgs(shapeArgs.BoardID, shapeArgs.Shape); err != nil {
+			return nil, err
+		}
+		// Same style composition CreateShape performs: base body carries data,
+		// position, geometry and parent; style is assembled separately and
+		// attached. Reusing these three helpers rather than re-deriving is what
+		// keeps colour normalization and text alignment identical across paths.
+		body = buildShapeBaseBody(shapeArgs.toCoreBody())
+		style, err := buildCreateShapeStyle(shapeArgs.Color, shapeArgs.TextColor)
+		if err != nil {
+			return nil, err
+		}
+		if err := applyShapeTextAlign(style, shapeArgs.TextAlign, shapeArgs.TextAlignVertical); err != nil {
+			return nil, err
+		}
+		if shapeArgs.FontSize > 0 {
+			style["fontSize"] = strconv.Itoa(shapeArgs.FontSize)
+		}
+		if len(style) > 0 {
+			body["style"] = style
+		}
+
+	case "text":
+		// Same fallback CreateText applies: a text item with no explicit
+		// text_color takes the generic color field.
+		textColor := item.TextColor
+		if textColor == "" {
+			textColor = item.Color
+		}
+		body, err = buildCreateTextBody(CreateTextArgs{
+			BoardID:  boardID,
+			Content:  item.Content,
+			X:        item.X,
+			Y:        item.Y,
+			Width:    item.Width,
+			FontSize: item.FontSize,
+			Color:    textColor,
+			ParentID: item.ParentID,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+	default:
+		return nil, fmt.Errorf("unsupported item type: %s", item.Type)
+	}
+
+	// The native endpoint discriminates on a top-level "type"; the per-endpoint
+	// builders above have no reason to set it, since their URL carries the type.
+	body["type"] = item.Type
+	return body, nil
+}
+
+// buildNativeBulkBody maps every item, or reports the first mapping failure.
+//
+// All-or-nothing on purpose: the endpoint is transactional, so sending a partial
+// batch would silently drop the unmappable items. The caller falls back to the
+// fan-out instead, where each bad item is reported individually.
+func buildNativeBulkBody(boardID string, items []BulkCreateItem) ([]map[string]interface{}, error) {
+	bodies := make([]map[string]interface{}, 0, len(items))
+	for i, item := range items {
+		body, err := bulkCreateItemBody(boardID, item)
+		if err != nil {
+			return nil, fmt.Errorf("item %d: %w", i+1, err)
+		}
+		bodies = append(bodies, body)
+	}
+	return bodies, nil
+}
+
+// nativeBulkRejectedBatch reports whether err is the API rejecting the whole
+// batch on validation, which transactionality proves created nothing.
+//
+// Only 400 qualifies. 429 and 5xx leave the outcome unknown, and treating them
+// as "nothing was created" is exactly the assumption that would duplicate items.
+func nativeBulkRejectedBatch(err error) bool {
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+	return apiErr.StatusCode == http.StatusBadRequest
+}
+
+// createItemsNative issues the single bulk call and returns the created IDs.
+func (c *Client) createItemsNative(ctx context.Context, boardID string, items []BulkCreateItem) ([]string, error) {
+	bodies, err := buildNativeBulkBody(boardID, items)
+	if err != nil {
+		return nil, err
+	}
+
+	respBody, err := c.request(ctx, http.MethodPost, "/boards/"+boardID+"/items/bulk", bodies)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return nil, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	ids := make([]string, 0, len(resp.Data))
+	for _, item := range resp.Data {
+		ids = append(ids, item.ID)
+	}
+	return ids, nil
+}
+
+// allItemsFailed builds the result for a batch whose outcome is unknown.
+//
+// Every item is attributed the same cause, categorized through the same
+// categorizeBulkError the fan-out uses, so retriability is decided by the HTTP
+// status rather than asserted here. The retry decision stays with the caller.
+func allItemsFailed(items []BulkCreateItem, cause error) BulkCreateResult {
+	failed := make([]BulkItemError, 0, len(items))
+	msgs := make([]string, 0, len(items))
+	for i := range items {
+		failed = append(failed, categorizeBulkError(i, "", cause))
+		msgs = append(msgs, fmt.Sprintf("item %d: %v", i+1, cause))
+	}
+	retriable := retriableIndexes(failed)
+	return BulkCreateResult{
+		Created:      0,
+		ItemIDs:      []string{},
+		Errors:       msgs,
+		FailedItems:  failed,
+		RetriableIDs: retriable,
+		Message: fmt.Sprintf(
+			"Created 0 of %d items: the bulk call failed as one transaction. %s",
+			len(items), transactionOutcomeNote(len(retriable))),
+	}
+}
+
+// transactionOutcomeNote states what the caller can and cannot conclude. The
+// honest answer is "almost certainly nothing was created, but not provably" —
+// a committed transaction whose response was lost is indistinguishable here.
+func transactionOutcomeNote(retriable int) string {
+	if retriable == 0 {
+		return "None were created."
+	}
+	return fmt.Sprintf(
+		"None were created unless the response was lost in transit, so check the board before retrying; %d items can be retried", retriable)
+}

--- a/miro/bulk_native_test.go
+++ b/miro/bulk_native_test.go
@@ -1,0 +1,293 @@
+package miro
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// bulkProbe records every request the client made, so a test can assert both
+// how many calls went out and where they went.
+type bulkProbe struct {
+	mu     sync.Mutex
+	paths  []string
+	bodies []string
+}
+
+func (p *bulkProbe) record(r *http.Request) {
+	body, _ := io.ReadAll(r.Body)
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.paths = append(p.paths, r.URL.Path)
+	p.bodies = append(p.bodies, string(body))
+}
+
+func (p *bulkProbe) calls() []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]string(nil), p.paths...)
+}
+
+func threeStickies() []BulkCreateItem {
+	return []BulkCreateItem{
+		{Type: "sticky_note", Content: "one", Color: "yellow"},
+		{Type: "sticky_note", Content: "two"},
+		{Type: "sticky_note", Content: "three"},
+	}
+}
+
+// bulkCreatedResponse is the native endpoint's 201 envelope.
+func bulkCreatedResponse(ids ...string) map[string]any {
+	data := make([]map[string]any, 0, len(ids))
+	for _, id := range ids {
+		data = append(data, map[string]any{"id": id})
+	}
+	return map[string]any{"type": "bulk-list", "data": data}
+}
+
+// TestBulkCreate_UsesOneRequest is the point of the change: N items used to
+// cost N requests, and now cost one.
+func TestBulkCreate_UsesOneRequest(t *testing.T) {
+	probe := &bulkProbe{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		probe.record(r)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(bulkCreatedResponse("i1", "i2", "i3"))
+	}))
+	defer server.Close()
+
+	client := newTestClientWithServer(server.URL)
+	result, err := client.BulkCreate(context.Background(), BulkCreateArgs{
+		BoardID: "board123",
+		Items:   threeStickies(),
+	})
+	if err != nil {
+		t.Fatalf("BulkCreate: %v", err)
+	}
+
+	calls := probe.calls()
+	if len(calls) != 1 {
+		t.Fatalf("made %d requests for 3 items, want 1: %v", len(calls), calls)
+	}
+	if !strings.HasSuffix(calls[0], "/items/bulk") {
+		t.Errorf("posted to %q, want /items/bulk", calls[0])
+	}
+	if result.Created != 3 || len(result.ItemIDs) != 3 {
+		t.Errorf("Created=%d IDs=%v, want 3", result.Created, result.ItemIDs)
+	}
+	if len(result.ItemURLs) != 3 {
+		t.Errorf("ItemURLs = %v, want one per created item", result.ItemURLs)
+	}
+	if len(result.Errors) != 0 {
+		t.Errorf("Errors = %v, want none", result.Errors)
+	}
+}
+
+// TestBulkCreate_ReusesStickyColorVocabulary pins the reason bulkCreateItemBody
+// calls the same builder the typed create does. Sticky fill colours are a named
+// enum, not hex, and a hand-rolled bulk mapping would be the obvious place for
+// that to drift.
+func TestBulkCreate_ReusesStickyColorVocabulary(t *testing.T) {
+	probe := &bulkProbe{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		probe.record(r)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(bulkCreatedResponse("i1"))
+	}))
+	defer server.Close()
+
+	client := newTestClientWithServer(server.URL)
+	if _, err := client.BulkCreate(context.Background(), BulkCreateArgs{
+		BoardID: "board123",
+		Items:   []BulkCreateItem{{Type: "sticky_note", Content: "hi", Color: "yellow"}},
+	}); err != nil {
+		t.Fatalf("BulkCreate: %v", err)
+	}
+
+	var sent []map[string]any
+	if err := json.Unmarshal([]byte(probe.bodies[0]), &sent); err != nil {
+		t.Fatalf("decode sent body: %v", err)
+	}
+	if sent[0]["type"] != "sticky_note" {
+		t.Errorf("type = %v, want sticky_note", sent[0]["type"])
+	}
+	style, ok := sent[0]["style"].(map[string]any)
+	if !ok {
+		t.Fatalf("no style block sent: %v", sent[0])
+	}
+	if got := style["fillColor"]; got != normalizeStickyColor("yellow") {
+		t.Errorf("fillColor = %v, want %v (normalized)", got, normalizeStickyColor("yellow"))
+	}
+}
+
+// TestBulkCreate_FallsBackOnValidationRejection covers the safe half of the
+// asymmetry. A 400 means the batch was rejected on validation, and the
+// endpoint's transactionality guarantees nothing was created — so re-running
+// per item cannot double-create, and is the only way to report WHICH item was
+// bad. The caller keeps the per-item contract at the cost of one extra request.
+func TestBulkCreate_FallsBackOnValidationRejection(t *testing.T) {
+	probe := &bulkProbe{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		probe.record(r)
+		w.Header().Set("Content-Type", "application/json")
+
+		if strings.HasSuffix(r.URL.Path, "/items/bulk") {
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]any{"message": "invalid item"})
+			return
+		}
+		// Per-item fan-out: every sticky succeeds individually.
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": "fanned"})
+	}))
+	defer server.Close()
+
+	client := newTestClientWithServer(server.URL)
+	result, err := client.BulkCreate(context.Background(), BulkCreateArgs{
+		BoardID: "board123",
+		Items:   threeStickies(),
+	})
+	if err != nil {
+		t.Fatalf("BulkCreate: %v", err)
+	}
+
+	calls := probe.calls()
+	if len(calls) != 4 {
+		t.Fatalf("made %d requests, want 4 (1 bulk + 3 fan-out): %v", len(calls), calls)
+	}
+	fanned := 0
+	for _, p := range calls {
+		if strings.HasSuffix(p, "/sticky_notes") {
+			fanned++
+		}
+	}
+	if fanned != 3 {
+		t.Errorf("fan-out issued %d per-item calls, want 3: %v", fanned, calls)
+	}
+	if result.Created != 3 {
+		t.Errorf("Created = %d, want 3 (fallback should still land every valid item)", result.Created)
+	}
+}
+
+// TestBulkCreate_DoesNotFallBackOnUnknownOutcome covers the dangerous half. A
+// 429 or 5xx leaves the outcome UNKNOWN — the transaction may have committed
+// with the response lost — so a fan-out here could create every item twice.
+//
+// This is the assertion that would catch someone "simplifying" the fallback to
+// fire on any error. The count is the whole test: exactly one request leaves.
+func TestBulkCreate_DoesNotFallBackOnUnknownOutcome(t *testing.T) {
+	for name, status := range map[string]int{
+		"rate limited": http.StatusTooManyRequests,
+		"server error": http.StatusInternalServerError,
+		"bad gateway":  http.StatusBadGateway,
+	} {
+		t.Run(name, func(t *testing.T) {
+			probe := &bulkProbe{}
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				probe.record(r)
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(status)
+				_ = json.NewEncoder(w).Encode(map[string]any{"message": "nope"})
+			}))
+			defer server.Close()
+
+			client := newTestClientWithServer(server.URL)
+			result, err := client.BulkCreate(context.Background(), BulkCreateArgs{
+				BoardID: "board123",
+				Items:   threeStickies(),
+			})
+			if err != nil {
+				t.Fatalf("BulkCreate returned a hard error, want a per-item result: %v", err)
+			}
+
+			for _, p := range probe.calls() {
+				if strings.HasSuffix(p, "/sticky_notes") {
+					t.Fatalf("fell back to the fan-out after an unknown-outcome failure; "+
+						"this can double-create. calls: %v", probe.calls())
+				}
+			}
+
+			if result.Created != 0 {
+				t.Errorf("Created = %d, want 0", result.Created)
+			}
+			if len(result.FailedItems) != 3 {
+				t.Errorf("FailedItems = %d, want 3 (every item accounted for)", len(result.FailedItems))
+			}
+			if len(result.RetriableIDs) != 3 {
+				t.Errorf("RetriableIDs = %v, want all three retriable on %s", result.RetriableIDs, name)
+			}
+			// The caller must be told the outcome is not provable, or they will
+			// retry blind and duplicate.
+			if !strings.Contains(result.Message, "lost in transit") {
+				t.Errorf("Message = %q, want it to flag the unprovable outcome", result.Message)
+			}
+		})
+	}
+}
+
+// TestBulkCreate_UnsupportedTypeFallsBack pins that a locally unmappable item
+// takes the fan-out path. Nothing was sent, so nothing was created, and the
+// fan-out reports the bad item by index while still landing the good ones.
+func TestBulkCreate_UnsupportedTypeFallsBack(t *testing.T) {
+	probe := &bulkProbe{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		probe.record(r)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": "ok1"})
+	}))
+	defer server.Close()
+
+	client := newTestClientWithServer(server.URL)
+	result, err := client.BulkCreate(context.Background(), BulkCreateArgs{
+		BoardID: "board123",
+		Items: []BulkCreateItem{
+			{Type: "sticky_note", Content: "fine"},
+			{Type: "hologram", Content: "not a thing"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("BulkCreate: %v", err)
+	}
+
+	for _, p := range probe.calls() {
+		if strings.HasSuffix(p, "/items/bulk") {
+			t.Errorf("sent an unmappable batch to the native endpoint: %v", probe.calls())
+		}
+	}
+	if result.Created != 1 {
+		t.Errorf("Created = %d, want 1 (the valid item should still land)", result.Created)
+	}
+	if len(result.FailedItems) != 1 {
+		t.Fatalf("FailedItems = %d, want 1", len(result.FailedItems))
+	}
+	if !strings.Contains(strings.Join(result.Errors, " "), "hologram") {
+		t.Errorf("Errors = %v, want the offending type named", result.Errors)
+	}
+}
+
+// TestNativeBulkRejectedBatch pins the status predicate directly, since the
+// safety of the fallback rests entirely on it.
+func TestNativeBulkRejectedBatch(t *testing.T) {
+	for status, want := range map[int]bool{
+		http.StatusBadRequest:          true,
+		http.StatusTooManyRequests:     false,
+		http.StatusInternalServerError: false,
+		http.StatusForbidden:           false,
+		http.StatusNotFound:            false,
+	} {
+		if got := nativeBulkRejectedBatch(&APIError{StatusCode: status}); got != want {
+			t.Errorf("nativeBulkRejectedBatch(%d) = %v, want %v", status, got, want)
+		}
+	}
+	if nativeBulkRejectedBatch(nil) {
+		t.Error("nativeBulkRejectedBatch(nil) = true, want false")
+	}
+}

--- a/miro/client_shapes_test.go
+++ b/miro/client_shapes_test.go
@@ -417,13 +417,34 @@ func TestBulkUpdate_TypeShapeRoutesToShapesEndpoint(t *testing.T) {
 	}
 }
 
+// TestBulkCreate_ShapeWithTextStyleFields pins that a shape created through the
+// bulk path carries the same style block a singly-created shape would.
+//
+// The body is now an ARRAY sent to /items/bulk rather than one object per
+// /shapes call, because BulkCreate uses Miro's native bulk endpoint. The
+// assertion is unchanged in substance and is the thing keeping bulk and single
+// creation from drifting: both go through buildShapeBaseBody.
 func TestBulkCreate_ShapeWithTextStyleFields(t *testing.T) {
+	var gotPath string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var body map[string]interface{}
+		gotPath = r.URL.Path
+
+		var body []map[string]interface{}
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 			t.Fatalf("decode body: %v", err)
 		}
-		style, ok := body["style"].(map[string]interface{})
+		if len(body) != 1 {
+			t.Fatalf("sent %d items, want 1", len(body))
+		}
+		item := body[0]
+
+		// The native endpoint discriminates on a top-level type; the URL no
+		// longer carries it.
+		if item["type"] != "shape" {
+			t.Errorf("type = %v, want shape", item["type"])
+		}
+
+		style, ok := item["style"].(map[string]interface{})
 		if !ok {
 			t.Fatal("expected style in request body for shape item")
 		}
@@ -433,11 +454,15 @@ func TestBulkCreate_ShapeWithTextStyleFields(t *testing.T) {
 		if style["textAlign"] != "right" {
 			t.Errorf("style.textAlign = %v, want 'right'", style["textAlign"])
 		}
+
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{
-			"id":   "shape999",
-			"data": map[string]interface{}{"shape": "circle", "content": "Bulk styled"},
+			"type": "bulk-list",
+			"data": []map[string]interface{}{{
+				"id":   "shape999",
+				"data": map[string]interface{}{"shape": "circle", "content": "Bulk styled"},
+			}},
 		})
 	}))
 	defer server.Close()
@@ -459,5 +484,8 @@ func TestBulkCreate_ShapeWithTextStyleFields(t *testing.T) {
 	}
 	if result.Created != 1 {
 		t.Errorf("Created = %d, want 1", result.Created)
+	}
+	if !strings.HasSuffix(gotPath, "/items/bulk") {
+		t.Errorf("posted to %q, want the native /items/bulk endpoint", gotPath)
 	}
 }

--- a/miro/interfaces.go
+++ b/miro/interfaces.go
@@ -129,6 +129,13 @@ type CommentService interface {
 	ResolveComment(ctx context.Context, args ResolveCommentArgs) (ResolveCommentResult, error)
 }
 
+// OrgAuditService handles Miro's organization audit log (Enterprise).
+// Distinct from the local execution log in miro/audit/, which is not an API
+// surface and so has no service here.
+type OrgAuditService interface {
+	GetOrgAuditLogs(ctx context.Context, args GetOrgAuditLogsArgs) (GetOrgAuditLogsResult, error)
+}
+
 // SVGService handles local SVG rendering and parsing.
 type SVGService interface {
 	ReadBoardSVG(ctx context.Context, args ReadBoardSVGArgs) (ReadBoardSVGResult, error)
@@ -207,6 +214,7 @@ type MiroClient interface {
 	MindmapService
 	CodeWidgetService
 	CommentService
+	OrgAuditService
 	SVGService
 	FrameService
 	TokenService

--- a/miro/orgaudit.go
+++ b/miro/orgaudit.go
@@ -1,0 +1,210 @@
+package miro
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// =============================================================================
+// Organization Audit Log (Miro Enterprise, GET /v2/audit/logs)
+// =============================================================================
+//
+// Miro's own organization-wide audit trail, NOT this server's local execution
+// log — that one lives in miro/audit/ behind GetAuditLog. The names are close
+// enough to confuse, so both tool descriptions say which is which.
+//
+// Two API facts the implementation depends on:
+//   - createdAfter and createdBefore are both REQUIRED; there is no default
+//     window, and omitting either is a 400 rather than a full-range query
+//   - the endpoint needs the auditlogs:read scope on an Enterprise plan, so a
+//     403 here usually means plan or scope rather than a genuine permission
+//     problem on a specific object
+
+// wrapEnterpriseAuditErr adds a plan/scope hint to the ambiguous statuses,
+// mirroring wrapExperimentalCommentErr.
+//
+// 403 and 404 are ambiguous on this endpoint: a non-Enterprise org, a token
+// without auditlogs:read, and a genuinely absent resource are indistinguishable
+// from the status alone. Other statuses are unambiguous and pass through
+// untouched — in particular 400, which is what a bad time window returns and
+// which a plan hint would actively mislead.
+func wrapEnterpriseAuditErr(err error) error {
+	if err == nil {
+		return nil
+	}
+	var apiErr *APIError
+	if !errors.As(err, &apiErr) {
+		return err
+	}
+	if apiErr.IsNotFound() || apiErr.IsForbidden() {
+		return fmt.Errorf("%w (note: the organization audit log is a Miro Enterprise feature and needs the auditlogs:read scope; this is not the same as miro_get_audit_log, which reads this server's local execution log)", err)
+	}
+	return err
+}
+
+// clampOrgAuditLimit bounds a requested page size.
+func clampOrgAuditLimit(n int) int {
+	if n <= 0 {
+		return DefaultOrgAuditLimit
+	}
+	if n > MaxOrgAuditLimit {
+		return MaxOrgAuditLimit
+	}
+	return n
+}
+
+// normalizeOrgAuditSorting validates the sort order. Empty means the API
+// default. An unrecognized value is rejected rather than silently dropped: a
+// caller who asked for ASC and got DESC would misread the page.
+func normalizeOrgAuditSorting(s string) (string, error) {
+	switch strings.ToUpper(strings.TrimSpace(s)) {
+	case "":
+		return "", nil
+	case OrgAuditSortAsc:
+		return OrgAuditSortAsc, nil
+	case OrgAuditSortDesc:
+		return OrgAuditSortDesc, nil
+	default:
+		return "", fmt.Errorf("sorting must be %s or %s, got %q", OrgAuditSortAsc, OrgAuditSortDesc, s)
+	}
+}
+
+// apiAuditEvent is the wire shape of one audit event.
+type apiAuditEvent struct {
+	ID        string `json:"id"`
+	Event     string `json:"event"`
+	Category  string `json:"category"`
+	CreatedAt string `json:"createdAt"`
+	CreatedBy *struct {
+		ID    string `json:"id"`
+		Name  string `json:"name"`
+		Email string `json:"email"`
+		Type  string `json:"type"`
+	} `json:"createdBy"`
+	Object *struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	} `json:"object"`
+	Context *struct {
+		IP   string `json:"ip"`
+		Team *struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		} `json:"team"`
+		Organization *struct {
+			ID string `json:"id"`
+		} `json:"organization"`
+	} `json:"context"`
+	Details map[string]any `json:"details"`
+}
+
+// summarizeOrgAuditEvent projects a wire event to the MCP-facing shape,
+// flattening the nested context so a caller need not walk it.
+func summarizeOrgAuditEvent(e apiAuditEvent) OrgAuditEvent {
+	out := OrgAuditEvent{
+		ID:        e.ID,
+		Event:     e.Event,
+		Category:  e.Category,
+		CreatedAt: e.CreatedAt,
+		Details:   e.Details,
+	}
+	if e.CreatedBy != nil {
+		out.CreatedBy = &OrgAuditActor{
+			ID:    e.CreatedBy.ID,
+			Name:  e.CreatedBy.Name,
+			Email: e.CreatedBy.Email,
+			Type:  e.CreatedBy.Type,
+		}
+	}
+	if e.Object != nil {
+		out.Object = &OrgAuditTarget{ID: e.Object.ID, Name: e.Object.Name}
+	}
+	if e.Context != nil {
+		out.IP = e.Context.IP
+		if e.Context.Team != nil {
+			out.TeamID = e.Context.Team.ID
+			out.TeamName = e.Context.Team.Name
+		}
+		if e.Context.Organization != nil {
+			out.OrganizationID = e.Context.Organization.ID
+		}
+	}
+	return out
+}
+
+// buildOrgAuditQuery assembles the query string, validating the two required
+// bounds up front so a missing one fails locally with a usable message rather
+// than as an opaque 400.
+func buildOrgAuditQuery(args GetOrgAuditLogsArgs) (string, error) {
+	if strings.TrimSpace(args.CreatedAfter) == "" {
+		return "", errors.New("created_after is required (ISO 8601, e.g. 2026-08-01T00:00:00Z); the API has no default time window")
+	}
+	if strings.TrimSpace(args.CreatedBefore) == "" {
+		return "", errors.New("created_before is required (ISO 8601, e.g. 2026-08-14T00:00:00Z); the API has no default time window")
+	}
+
+	sorting, err := normalizeOrgAuditSorting(args.Sorting)
+	if err != nil {
+		return "", err
+	}
+
+	params := url.Values{}
+	params.Set("createdAfter", args.CreatedAfter)
+	params.Set("createdBefore", args.CreatedBefore)
+	params.Set("limit", strconv.Itoa(clampOrgAuditLimit(args.Limit)))
+	if args.Cursor != "" {
+		params.Set("cursor", args.Cursor)
+	}
+	if sorting != "" {
+		params.Set("sorting", sorting)
+	}
+	return params.Encode(), nil
+}
+
+// GetOrgAuditLogs fetches a page of Miro's organization audit log.
+//
+// Enterprise plan and the auditlogs:read scope are required; see
+// wrapEnterpriseAuditErr for how that surfaces.
+func (c *Client) GetOrgAuditLogs(ctx context.Context, args GetOrgAuditLogsArgs) (GetOrgAuditLogsResult, error) {
+	query, err := buildOrgAuditQuery(args)
+	if err != nil {
+		return GetOrgAuditLogsResult{}, err
+	}
+
+	respBody, err := c.request(ctx, http.MethodGet, "/audit/logs?"+query, nil)
+	if err != nil {
+		return GetOrgAuditLogsResult{}, wrapEnterpriseAuditErr(err)
+	}
+
+	var resp struct {
+		Data   []apiAuditEvent `json:"data"`
+		Limit  int             `json:"limit"`
+		Size   int             `json:"size"`
+		Cursor string          `json:"cursor"`
+	}
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return GetOrgAuditLogsResult{}, fmt.Errorf("failed to parse response: %w", err)
+	}
+
+	events := make([]OrgAuditEvent, 0, len(resp.Data))
+	for _, wire := range resp.Data {
+		events = append(events, summarizeOrgAuditEvent(wire))
+	}
+
+	result := GetOrgAuditLogsResult{
+		Events:  events,
+		Count:   len(events),
+		Cursor:  resp.Cursor,
+		HasMore: resp.Cursor != "",
+	}
+	if result.Count == 0 {
+		result.Message = fmt.Sprintf("No audit events between %s and %s", args.CreatedAfter, args.CreatedBefore)
+	}
+	return result, nil
+}

--- a/miro/orgaudit_test.go
+++ b/miro/orgaudit_test.go
@@ -1,0 +1,269 @@
+package miro
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// orgAuditSample is a two-event page shaped the way GET /v2/audit/logs answers:
+// a cursor-list envelope, actor under createdBy, and team/org/ip buried in a
+// nested context object.
+const orgAuditSample = `{
+  "type": "cursor-list",
+  "limit": 50,
+  "size": 2,
+  "cursor": "2026-08-01T09:30:10.840687Z#1234567890123456789-DDB",
+  "data": [
+    {
+      "id": "evt-1",
+      "event": "board_created",
+      "category": "boards",
+      "createdAt": "2026-08-12T09:14:00Z",
+      "createdBy": {"type": "user", "id": "u-1", "name": "Olga Safonova", "email": "olga@example.com"},
+      "object": {"id": "b-1", "name": "Design Sprint"},
+      "context": {
+        "ip": "203.0.113.7",
+        "team": {"id": "t-1", "name": "Design"},
+        "organization": {"id": "org-1"}
+      },
+      "details": {"boardPolicy": "private"}
+    },
+    {
+      "id": "evt-2",
+      "event": "user_invited",
+      "category": "users",
+      "createdAt": "2026-08-12T10:02:00Z"
+    }
+  ]
+}`
+
+// newOrgAuditServer captures the query string the client sent and replies with
+// the supplied body.
+func newOrgAuditServer(t *testing.T, body string, gotQuery *string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if gotQuery != nil {
+			*gotQuery = r.URL.RawQuery
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+}
+
+// TestGetOrgAuditLogs_FlattensContext pins the projection. The API buries team,
+// organization and IP inside a nested context object; a caller filtering by
+// team should not have to walk it, so those are flattened onto the event.
+func TestGetOrgAuditLogs_FlattensContext(t *testing.T) {
+	server := newOrgAuditServer(t, orgAuditSample, nil)
+	defer server.Close()
+
+	client := newTestClientWithServer(server.URL)
+	result, err := client.GetOrgAuditLogs(context.Background(), GetOrgAuditLogsArgs{
+		CreatedAfter:  "2026-08-01T00:00:00Z",
+		CreatedBefore: "2026-08-14T00:00:00Z",
+	})
+	if err != nil {
+		t.Fatalf("GetOrgAuditLogs: %v", err)
+	}
+
+	if result.Count != 2 {
+		t.Fatalf("Count = %d, want 2", result.Count)
+	}
+
+	first := result.Events[0]
+	if first.TeamID != "t-1" || first.TeamName != "Design" {
+		t.Errorf("team = %q/%q, want t-1/Design", first.TeamID, first.TeamName)
+	}
+	if first.OrganizationID != "org-1" {
+		t.Errorf("organization = %q, want org-1", first.OrganizationID)
+	}
+	if first.IP != "203.0.113.7" {
+		t.Errorf("ip = %q, want 203.0.113.7", first.IP)
+	}
+	if first.CreatedBy == nil || first.CreatedBy.Email != "olga@example.com" {
+		t.Errorf("createdBy = %+v, want the actor with email", first.CreatedBy)
+	}
+	if first.Object == nil || first.Object.Name != "Design Sprint" {
+		t.Errorf("object = %+v, want the target board", first.Object)
+	}
+	if first.Details["boardPolicy"] != "private" {
+		t.Errorf("details = %v, want boardPolicy preserved", first.Details)
+	}
+
+	// An event with no context, actor or object must project cleanly rather
+	// than panic or invent empty structs.
+	second := result.Events[1]
+	if second.CreatedBy != nil || second.Object != nil {
+		t.Errorf("sparse event gained structs: createdBy=%+v object=%+v", second.CreatedBy, second.Object)
+	}
+	if second.TeamID != "" || second.IP != "" {
+		t.Errorf("sparse event gained context: team=%q ip=%q", second.TeamID, second.IP)
+	}
+
+	// Cursor drives HasMore; the caller should not infer paging state itself.
+	if !result.HasMore || result.Cursor == "" {
+		t.Errorf("HasMore=%v Cursor=%q, want true and non-empty", result.HasMore, result.Cursor)
+	}
+}
+
+// TestGetOrgAuditLogs_RequiresTimeWindow pins that the two mandatory bounds
+// fail locally with a usable message. The API returns an opaque 400 for a
+// missing bound, and an agent that has to decode a 400 to learn a parameter was
+// required will burn a turn doing it.
+func TestGetOrgAuditLogs_RequiresTimeWindow(t *testing.T) {
+	called := false
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		called = true
+	}))
+	defer server.Close()
+	client := newTestClientWithServer(server.URL)
+
+	for name, args := range map[string]GetOrgAuditLogsArgs{
+		"missing after":  {CreatedBefore: "2026-08-14T00:00:00Z"},
+		"missing before": {CreatedAfter: "2026-08-01T00:00:00Z"},
+		"both missing":   {},
+		"blank after":    {CreatedAfter: "   ", CreatedBefore: "2026-08-14T00:00:00Z"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := client.GetOrgAuditLogs(context.Background(), args)
+			if err == nil {
+				t.Fatal("expected an error for an incomplete time window")
+			}
+			if !strings.Contains(err.Error(), "required") {
+				t.Errorf("error = %v, want it to say the field is required", err)
+			}
+		})
+	}
+
+	if called {
+		t.Error("client issued an HTTP request despite an invalid time window")
+	}
+}
+
+// TestGetOrgAuditLogs_QueryString pins the wire parameter names. They are
+// camelCase (createdAfter) while the tool arguments are snake_case
+// (created_after), so a rename on either side breaks silently — the API ignores
+// unknown query parameters and would answer with an unfiltered page.
+func TestGetOrgAuditLogs_QueryString(t *testing.T) {
+	var got string
+	server := newOrgAuditServer(t, `{"data":[],"size":0}`, &got)
+	defer server.Close()
+
+	client := newTestClientWithServer(server.URL)
+	if _, err := client.GetOrgAuditLogs(context.Background(), GetOrgAuditLogsArgs{
+		CreatedAfter:  "2026-08-01T00:00:00Z",
+		CreatedBefore: "2026-08-14T00:00:00Z",
+		Limit:         10,
+		Cursor:        "cur-1",
+		Sorting:       "asc",
+	}); err != nil {
+		t.Fatalf("GetOrgAuditLogs: %v", err)
+	}
+
+	for _, want := range []string{
+		"createdAfter=2026-08-01T00%3A00%3A00Z",
+		"createdBefore=2026-08-14T00%3A00%3A00Z",
+		"limit=10",
+		"cursor=cur-1",
+		"sorting=ASC", // normalized to the enum the API accepts
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("query %q missing %q", got, want)
+		}
+	}
+}
+
+// TestGetOrgAuditLogs_LimitAndSorting covers the two normalizers.
+func TestGetOrgAuditLogs_LimitAndSorting(t *testing.T) {
+	t.Run("limit clamps", func(t *testing.T) {
+		for in, want := range map[int]int{
+			0:    DefaultOrgAuditLimit,
+			-5:   DefaultOrgAuditLimit,
+			10:   10,
+			1000: MaxOrgAuditLimit,
+		} {
+			if got := clampOrgAuditLimit(in); got != want {
+				t.Errorf("clampOrgAuditLimit(%d) = %d, want %d", in, got, want)
+			}
+		}
+	})
+
+	t.Run("unknown sorting is rejected", func(t *testing.T) {
+		// Rejected rather than dropped: a caller who asked for ASC and
+		// silently got the API default would misread the page order.
+		if _, err := normalizeOrgAuditSorting("sideways"); err == nil {
+			t.Error("expected an error for an unrecognized sort order")
+		}
+		if got, err := normalizeOrgAuditSorting(""); err != nil || got != "" {
+			t.Errorf("empty sorting = %q, %v; want passthrough", got, err)
+		}
+	})
+}
+
+// TestGetOrgAuditLogs_EnterpriseHintByStatus pins which statuses get the
+// plan/scope hint. 403 and 404 are ambiguous here — non-Enterprise org, missing
+// auditlogs:read scope, and a genuinely absent resource look identical. Other
+// statuses are unambiguous, and 400 in particular must NOT get the hint: that
+// is what a malformed time window returns, and a plan hint would send the
+// caller chasing the wrong problem.
+func TestGetOrgAuditLogs_EnterpriseHintByStatus(t *testing.T) {
+	tests := []struct {
+		status   int
+		wantHint bool
+	}{
+		{http.StatusForbidden, true},
+		{http.StatusNotFound, true},
+		{http.StatusBadRequest, false},
+		{http.StatusInternalServerError, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(http.StatusText(tt.status), func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tt.status)
+				_ = json.NewEncoder(w).Encode(map[string]any{"message": "boom"})
+			}))
+			defer server.Close()
+
+			client := newTestClientWithServer(server.URL)
+			_, err := client.GetOrgAuditLogs(context.Background(), GetOrgAuditLogsArgs{
+				CreatedAfter:  "2026-08-01T00:00:00Z",
+				CreatedBefore: "2026-08-14T00:00:00Z",
+			})
+			if err == nil {
+				t.Fatalf("expected an error for status %d", tt.status)
+			}
+			if got := strings.Contains(err.Error(), "Enterprise"); got != tt.wantHint {
+				t.Errorf("hint present = %v, want %v (err: %v)", got, tt.wantHint, err)
+			}
+		})
+	}
+}
+
+// TestGetOrgAuditLogs_EmptyPageIsExplicit pins the zero-result signal. An agent
+// cannot tell an empty array from a silently failed call, so the result names
+// the window it searched.
+func TestGetOrgAuditLogs_EmptyPageIsExplicit(t *testing.T) {
+	server := newOrgAuditServer(t, `{"data":[],"size":0}`, nil)
+	defer server.Close()
+
+	client := newTestClientWithServer(server.URL)
+	result, err := client.GetOrgAuditLogs(context.Background(), GetOrgAuditLogsArgs{
+		CreatedAfter:  "2026-08-01T00:00:00Z",
+		CreatedBefore: "2026-08-14T00:00:00Z",
+	})
+	if err != nil {
+		t.Fatalf("GetOrgAuditLogs: %v", err)
+	}
+	if result.Count != 0 || result.HasMore {
+		t.Errorf("Count=%d HasMore=%v, want 0 and false", result.Count, result.HasMore)
+	}
+	if !strings.Contains(result.Message, "2026-08-01T00:00:00Z") {
+		t.Errorf("Message = %q, want it to name the searched window", result.Message)
+	}
+}

--- a/miro/sticky.go
+++ b/miro/sticky.go
@@ -21,39 +21,7 @@ func (c *Client) CreateSticky(ctx context.Context, args CreateStickyArgs) (Creat
 		return CreateStickyResult{}, fmt.Errorf("content is required")
 	}
 
-	// Build request body
-	reqBody := map[string]interface{}{
-		"data": map[string]interface{}{
-			"content": args.Content,
-			"shape":   "square",
-		},
-		"position": map[string]interface{}{
-			"x":      args.X,
-			"y":      args.Y,
-			"origin": "center",
-		},
-	}
-
-	// Add style if color specified
-	if args.Color != "" {
-		reqBody["style"] = map[string]interface{}{
-			"fillColor": normalizeStickyColor(args.Color),
-		}
-	}
-
-	// Add geometry if width specified
-	if args.Width > 0 {
-		reqBody["geometry"] = map[string]interface{}{
-			"width": args.Width,
-		}
-	}
-
-	// Add parent if specified
-	if args.ParentID != "" {
-		reqBody["parent"] = map[string]interface{}{
-			"id": args.ParentID,
-		}
-	}
+	reqBody := buildStickyCreateBody(args)
 
 	respBody, err := c.request(ctx, http.MethodPost, "/boards/"+args.BoardID+"/sticky_notes", reqBody)
 	if err != nil {
@@ -75,6 +43,43 @@ func (c *Client) CreateSticky(ctx context.Context, args CreateStickyArgs) (Creat
 		Color:   sticky.Style.FillColor,
 		Message: fmt.Sprintf("Created sticky note '%s'", truncate(args.Content, 30)),
 	}, nil
+}
+
+// buildStickyCreateBody assembles the POST body for a sticky create.
+//
+// Extracted so the native bulk-create path can produce a byte-identical body
+// without going through CreateSticky's HTTP call. Duplicating this mapping
+// instead would put the sticky colour vocabulary (normalizeStickyColor) in two
+// places, and a bulk-created sticky would drift from a singly-created one the
+// first time either side changed.
+func buildStickyCreateBody(args CreateStickyArgs) map[string]interface{} {
+	body := map[string]interface{}{
+		"data": map[string]interface{}{
+			"content": args.Content,
+			"shape":   "square",
+		},
+		"position": map[string]interface{}{
+			"x":      args.X,
+			"y":      args.Y,
+			"origin": "center",
+		},
+	}
+	if args.Color != "" {
+		body["style"] = map[string]interface{}{
+			"fillColor": normalizeStickyColor(args.Color),
+		}
+	}
+	if args.Width > 0 {
+		body["geometry"] = map[string]interface{}{
+			"width": args.Width,
+		}
+	}
+	if args.ParentID != "" {
+		body["parent"] = map[string]interface{}{
+			"id": args.ParentID,
+		}
+	}
+	return body
 }
 
 // buildUpdateStickyBody assembles the PATCH body for a sticky update.

--- a/miro/types_orgaudit.go
+++ b/miro/types_orgaudit.go
@@ -1,0 +1,102 @@
+package miro
+
+// =============================================================================
+// Organization Audit Log Types (Miro Enterprise, GET /v2/audit/logs)
+// =============================================================================
+//
+// Distinct from the types in types_audit.go, which describe THIS server's local
+// execution log. These describe Miro's own organization-wide audit trail: who
+// did what in the Miro workspace, including actions taken outside this server.
+// The two share nothing but the word "audit".
+
+// OrgAuditSortAsc and OrgAuditSortDesc are the sort orders the API accepts.
+const (
+	OrgAuditSortAsc  = "ASC"
+	OrgAuditSortDesc = "DESC"
+)
+
+// DefaultOrgAuditLimit is the page size when the caller doesn't specify one.
+const DefaultOrgAuditLimit = 50
+
+// MaxOrgAuditLimit caps a requested page size.
+const MaxOrgAuditLimit = 100
+
+// GetOrgAuditLogsArgs specifies the query for Miro's organization audit log.
+//
+// created_after and created_before are both REQUIRED by the API — it has no
+// default window. Miro retains 90 days; older events are only available via
+// the CSV export in the Miro admin UI, which this tool does not wrap.
+type GetOrgAuditLogsArgs struct {
+	// CreatedAfter is the start of the window (required).
+	CreatedAfter string `json:"created_after" jsonschema:"REQUIRED. Start of the time window (ISO 8601, e.g. 2026-08-01T00:00:00Z). Miro retains 90 days."`
+
+	// CreatedBefore is the end of the window (required).
+	CreatedBefore string `json:"created_before" jsonschema:"REQUIRED. End of the time window (ISO 8601, e.g. 2026-08-14T00:00:00Z)."`
+
+	// Limit is the page size (default 50, max 100).
+	Limit int `json:"limit,omitempty" jsonschema:"Max events per page (default 50, max 100)"`
+
+	// Cursor continues a previous page.
+	Cursor string `json:"cursor,omitempty" jsonschema:"Pagination cursor from a previous response"`
+
+	// Sorting orders results by creation time.
+	Sorting string `json:"sorting,omitempty" jsonschema:"Sort order by creation time: ASC or DESC (default DESC)"`
+}
+
+// OrgAuditActor is the user who performed an audited action.
+type OrgAuditActor struct {
+	ID    string `json:"id,omitempty"`
+	Name  string `json:"name,omitempty"`
+	Email string `json:"email,omitempty"`
+	Type  string `json:"type,omitempty"`
+}
+
+// OrgAuditTarget is the object an audited action was performed on.
+type OrgAuditTarget struct {
+	ID   string `json:"id,omitempty"`
+	Name string `json:"name,omitempty"`
+}
+
+// OrgAuditEvent is one entry in Miro's organization audit log.
+type OrgAuditEvent struct {
+	ID        string          `json:"id"`
+	Event     string          `json:"event"`
+	Category  string          `json:"category,omitempty"`
+	CreatedAt string          `json:"created_at,omitempty"`
+	CreatedBy *OrgAuditActor  `json:"created_by,omitempty"`
+	Object    *OrgAuditTarget `json:"object,omitempty"`
+
+	// TeamID and TeamName come from the event's context, flattened because a
+	// caller filtering by team should not have to walk a nested object.
+	TeamID   string `json:"team_id,omitempty"`
+	TeamName string `json:"team_name,omitempty"`
+
+	// OrganizationID likewise comes from context.
+	OrganizationID string `json:"organization_id,omitempty"`
+
+	// IP is the source address recorded for the action.
+	IP string `json:"ip,omitempty"`
+
+	// Details is the event-specific payload. Left as raw JSON shape because it
+	// varies per event type and Miro documents no schema for it; projecting it
+	// would mean guessing.
+	Details map[string]any `json:"details,omitempty"`
+}
+
+// GetOrgAuditLogsResult is one page of organization audit events.
+type GetOrgAuditLogsResult struct {
+	Events []OrgAuditEvent `json:"events"`
+
+	// Count is the number of events in this page.
+	Count int `json:"count"`
+
+	// Cursor is the token for the next page. Empty means this is the last page.
+	Cursor string `json:"cursor,omitempty"`
+
+	// HasMore reports whether another page exists, so a caller does not have to
+	// infer it from the cursor being non-empty.
+	HasMore bool `json:"has_more"`
+
+	// Message carries an explicit zero-result signal.
+	Message string `json:"message,omitempty"`
+}

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.olgasafonova/miro-mcp-server",
-  "description": "Control Miro whiteboards with AI. 105 tools for boards, diagrams, mindmaps, comments, SVG.",
+  "description": "Control Miro whiteboards with AI. 106 tools for boards, diagrams, mindmaps, comments, SVG.",
   "title": "Miro",
   "repository": {
     "url": "https://github.com/olgasafonova/miro-mcp-server",

--- a/tools/definitions.go
+++ b/tools/definitions.go
@@ -1375,9 +1375,25 @@ VOICE-FRIENDLY: "Export 50% complete: 5 of 10 boards exported"`,
 		Title:    "Get Audit Log",
 		Category: "audit",
 		ReadOnly: true,
-		Description: `Query local audit log for MCP tool executions (this session only). Filter by time range, tool, board, action type, or success/failure.
+		Description: `Query THIS SERVER's local execution log — which MCP tools ran here, when, and whether they succeeded. Covers this process only; it knows nothing about actions taken in Miro's UI or by other clients.
 
-RETURNS: Array of audit entries with timestamps, tool names, board IDs, and outcomes. Paginated via cursor.`,
+USE WHEN debugging what this server did. For who did what in the Miro workspace, use miro_get_org_audit_logs instead.
+
+Filter by time range, tool, board, action type, or success/failure. RETURNS: Array of entries with timestamps, tool names, board IDs, and outcomes.`,
+	},
+	{
+		Name:     "miro_get_org_audit_logs",
+		Method:   "GetOrgAuditLogs",
+		Title:    "Get Organization Audit Logs",
+		Category: "audit",
+		ReadOnly: true,
+		Description: `Query MIRO's organization-wide audit log — who did what across the Miro workspace, including actions taken outside this server. ENTERPRISE ONLY; needs the auditlogs:read scope.
+
+USE WHEN investigating workspace activity, access changes, or board history across users. For what this server itself executed, use miro_get_audit_log instead.
+
+created_after and created_before are BOTH REQUIRED — the API has no default window. Miro retains 90 days; older events are only available via the CSV export in the Miro admin UI.
+
+RETURNS: Cursor-paginated events with actor (name/email), target object, event type, category, team, and source IP.`,
 	},
 	{
 		Name:     "miro_get_desire_paths",

--- a/tools/definitions_test.go
+++ b/tools/definitions_test.go
@@ -130,7 +130,8 @@ func TestToolCount(t *testing.T) {
 	// v1.22.0: +6 code widget tools (create, get, list, update, move, delete; v2-experimental) = 98
 	// v1.23.0: +5 comment tools (create, list, get, reply, resolve; v2-experimental)
 	//          +2 canvas SVG tools (read_board_svg, create_from_svg; local transform) = 105
-	expectedCount := 105
+	// unreleased: +1 miro_get_org_audit_logs (Miro Enterprise GET /v2/audit/logs) = 106
+	expectedCount := 106
 	if len(AllTools) != expectedCount {
 		t.Errorf("expected %d tools, got %d", expectedCount, len(AllTools))
 	}

--- a/tools/handlers.go
+++ b/tools/handlers.go
@@ -250,8 +250,10 @@ func (h *HandlerRegistry) structureHandlers() map[string]func(*mcp.Server, *mcp.
 		"GetComment":     makeHandler(h, h.client.GetComment),
 		"ReplyComment":   makeHandler(h, h.client.ReplyComment),
 		"ResolveComment": makeHandler(h, h.client.ResolveComment),
-		"ReadBoardSVG":   makeHandler(h, h.client.ReadBoardSVG),
-		"CreateFromSVG":  makeHandler(h, h.client.CreateFromSVG),
+
+		"GetOrgAuditLogs": makeHandler(h, h.client.GetOrgAuditLogs),
+		"ReadBoardSVG":    makeHandler(h, h.client.ReadBoardSVG),
+		"CreateFromSVG":   makeHandler(h, h.client.CreateFromSVG),
 
 		"CreateCodeWidget": makeHandler(h, h.client.CreateCodeWidget),
 		"GetCodeWidget":    makeHandler(h, h.client.GetCodeWidget),

--- a/tools/mock_client_test.go
+++ b/tools/mock_client_test.go
@@ -109,6 +109,8 @@ type MockClient struct {
 	ReadBoardSVGFn   func(ctx context.Context, args miro.ReadBoardSVGArgs) (miro.ReadBoardSVGResult, error)
 	CreateFromSVGFn  func(ctx context.Context, args miro.CreateFromSVGArgs) (miro.CreateFromSVGResult, error)
 
+	GetOrgAuditLogsFn func(ctx context.Context, args miro.GetOrgAuditLogsArgs) (miro.GetOrgAuditLogsResult, error)
+
 	CreateCodeWidgetFn func(ctx context.Context, args miro.CreateCodeWidgetArgs) (miro.CreateCodeWidgetResult, error)
 	GetCodeWidgetFn    func(ctx context.Context, args miro.GetCodeWidgetArgs) (miro.GetCodeWidgetResult, error)
 	ListCodeWidgetsFn  func(ctx context.Context, args miro.ListCodeWidgetsArgs) (miro.ListCodeWidgetsResult, error)
@@ -1144,6 +1146,17 @@ func (m *MockClient) CreateComment(ctx context.Context, args miro.CreateCommentA
 		ID:      "comment-123",
 		ItemID:  args.ItemID,
 		Message: "Created comment thread",
+	}, nil
+}
+
+func (m *MockClient) GetOrgAuditLogs(ctx context.Context, args miro.GetOrgAuditLogsArgs) (miro.GetOrgAuditLogsResult, error) {
+	m.recordCall("GetOrgAuditLogs", args)
+	if m.GetOrgAuditLogsFn != nil {
+		return m.GetOrgAuditLogsFn(ctx, args)
+	}
+	return miro.GetOrgAuditLogsResult{
+		Events: []miro.OrgAuditEvent{{ID: "audit-123", Event: "board_created", Category: "boards"}},
+		Count:  1,
 	}, nil
 }
 


### PR DESCRIPTION
Closes `miro-mcp-server-1rq` and `miro-mcp-server-1vn`. Two P3s in one branch — they touch different files and are reviewable independently, commit by commit.

---

# 1. `miro_get_org_audit_logs` (commit 1)

`miro_get_audit_log` reads **this server's** local execution log. Miro's own organization audit log was uncovered entirely, and the tool name made that easy to misread. Adds a distinct tool; both descriptions now name the other.

**The existing tool keeps its name.** The bead floated renaming it; renaming breaks callers for a problem sharper wording fixes.

Two API facts drive the implementation:

- **`created_after` / `created_before` are both required.** No default window, and a missing bound returns an opaque 400. Both validated locally so the caller gets a usable message instead of decoding an HTTP error.
- **403 and 404 are ambiguous.** Enterprise plan *and* `auditlogs:read` scope are needed, so non-Enterprise org, missing scope, and genuinely-absent resource are indistinguishable. Those two get a plan hint; everything else passes through. **400 deliberately does not** — that is the malformed-window status, and a plan hint would misdirect. A test pins which statuses get it.

The nested `context` object is flattened, so `team_id`/`team_name`/`organization_id`/`ip` sit on the event. `details` stays a raw map: it varies per event type and Miro documents no schema, so projecting would mean guessing.

**Also corrects the README account table**, which claimed every plan had full access. That was *already* untrue for the three PDF/SVG export tools. Now 102 of 106 on Free/Team/Business, with the four Enterprise-only tools named. `miro_get_board_picture` is not one of them — verified rather than assumed.

Tool count 105 → 106; preload regenerated with `cmd/token-count` (19,027 → 19,317).

---

# 2. Native bulk create (commit 2)

`miro_bulk_create` issued one request per item. It now posts to `POST /v2/boards/{board_id}/items/bulk`. `MaxBulkItems` was already 20 — the endpoint's own cap — so every accepted request fits one call. **20 stickies now cost 1 request instead of 20.**

## What the bead asked me to measure first

| Question | Answer |
|---|---|
| Does it support every item type we create? | Yes — `app_card, text, shape, sticky_note, image, document, card, frame, embed`, a superset of the three we handle. Not a constraint. |
| Does the error shape preserve per-item reporting? | **No.** The endpoint is transactional: *"if any item's create operation fails... none of the items will be created."* |

The second answer changed the design.

## The fallback is deliberately asymmetric

| Failure | Behaviour | Why |
|---|---|---|
| `400` | Fall back to per-item fan-out | Batch rejected on validation; transactionality **proves** nothing was created, so re-running cannot double-create — and it is the only way to report *which* item was bad. Costs one extra request on the error path; the caller's contract is unchanged. |
| `429`, `5xx`, network, timeout | Do **not** fall back | Outcome is **unknown** — the transaction may have committed with the response lost. A fan-out here could create every item twice. Reports all items failed and retriable, and says the outcome is not provable. |

`TestBulkCreate_DoesNotFallBackOnUnknownOutcome` exists solely to fail if someone widens that condition to "any error".

## Byte-identical bodies

Item bodies reuse the same builders the typed `Create*` methods use, so a bulk-created item matches a singly-created one. This matters most for sticky fill colours — a named enum the API rejects hex for, and the first place a hand-rolled bulk mapping would drift. `buildStickyCreateBody` was extracted from `CreateSticky` for this; the existing sticky tests guard the extraction.

`TestBulkCreate_ShapeWithTextStyleFields` updated to the new wire format and strengthened to assert the endpoint as well as the style block.

---

`make check` green on both commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)