### PR TITLE
docs: re-enumerate official Miro MCP surface at 61 tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,11 +468,11 @@ sequenceDiagram
 
 ## Official vs Community
 
-Miro released their [official MCP server](https://miro.com/ai/mcp/) in December 2025 and has grown it substantially since. Comparison refreshed 18-08-2026 by enumerating the **63 tools** the hosted server actually registers at `mcp.miro.com`, rather than counting the [documented set](https://developers.miro.com/docs/miro-mcp-prompts) — the docs lag the deployment in both directions: `board_trash` and `space_delete`, present on 17-08-2026, were gone the next day, leaving the surface with no hard-destructive verbs. Recent additions come from their changelogs on [new MCP tools](https://developers.miro.com/changelog/new-miro-mcp-server-tools-create-items-boards-code-widgets-read-comments-and-more) and [code widget endpoints](https://developers.miro.com/changelog/new-endpoints-create-and-manage-code-widgets).
+Miro released their [official MCP server](https://miro.com/ai/mcp/) in December 2025 and has grown it substantially since. Comparison refreshed 09-09-2026 by enumerating the **61 tools** the hosted server actually registers at `mcp.miro.com`, rather than counting the [documented set](https://developers.miro.com/docs/miro-mcp-prompts) — the docs lag the deployment in both directions: `board_trash` and `space_delete`, present on 17-08-2026, were gone the next day, leaving the surface with no hard-destructive verbs, and all five `code_widget_*` tools present on 18-08-2026 were gone by 09-09-2026, while `canvas_search`, `canvas_load_format_skill` and `content_item_list_roles` arrived. Recent additions come from their changelogs on [new MCP tools](https://developers.miro.com/changelog/new-miro-mcp-server-tools-create-items-boards-code-widgets-read-comments-and-more) and [code widget endpoints](https://developers.miro.com/changelog/new-endpoints-create-and-manage-code-widgets).
 
 | Feature | This Server | Official Miro MCP |
 |---------|-------------|-------------------|
-| **Tools** | 110 (or 15 in `essentials` profile) | 63 |
+| **Tools** | 110 (or 15 in `essentials` profile) | 61 |
 | **Transport** | stdio + HTTP | HTTPS only (hosted at mcp.miro.com) |
 | **Self-hosting** | Yes | No |
 | **Offline mode** | Yes | No |
@@ -481,11 +481,11 @@ Miro released their [official MCP server](https://miro.com/ai/mcp/) in December 
 | **Diagram generation** | Mermaid, parsed locally; native diagram items readable via `miro_list_diagrams`/`miro_get_diagram` | Mermaid (`diagram_create_mermaid`, `diagram_update_mermaid`) plus a custom DSL |
 | **AI context** | No | Yes (`context_explore`, `context_get`) |
 | **Layout DSL** | Composed from bulk create + the [`miro-workflow`](skills/miro-workflow/) skill | Yes, but marked deprecated upstream in favour of the canvas tools |
-| **Canvas as SVG** | Read + create + update (`data-miro-id` diff; local geometry transform; spatial approximation). Reads scope to a single frame via `frame_id`, and read output is directly re-submittable to the update tool | Yes (read, create, update from SVG). Reads are whole-board only, and read output is re-escaped, so it cannot be fed back to the update tool verbatim |
+| **Canvas as SVG** | Read + create + update (`data-miro-id` diff; local geometry transform; spatial approximation). Reads scope to a single frame via `frame_id`, and read output is directly re-submittable to the update tool | Yes (read, create, update from SVG). Reads scope to a rectangle or a `widget_ids` list and refuse areas above 500 widgets; `canvas_search` (pattern and regex over the SVG) narrows the scope first. Read output is re-escaped, so it cannot be fed back to the update tool verbatim |
 | **Spaces & sections** | No | Yes (10 tools) — workspace-level grouping of boards, not board content |
 | **Comments** | Yes (create, list, get, reply, resolve; v2-experimental) | Yes (create, list, reply, resolve) |
 | **Prototypes** | No | Yes (read, create, upload URL) |
-| **Code widgets** | 6 tools incl. position move (v2-experimental) | 5 tools (no move) |
+| **Code widgets** | 6 tools incl. position move (v2-experimental) | None since 09-09-2026 (5 tools on 18-08-2026) |
 | **Docs & Tables** | Doc formats + table read | Doc create/update + table create/sync/history |
 | **Images** | Create, upload, update from file | Create, upload URL, get data/URL |
 | **Bulk operations** | Yes | Partial (`table_sync_rows` upsert only) |
@@ -493,7 +493,7 @@ Miro released their [official MCP server](https://miro.com/ai/mcp/) in December 
 | **Tags & Groups** | Yes | No |
 | **Connectors CRUD** | Yes | No |
 | **Item-level CRUD** | Yes (sticky, shape, text, card, image, document, embed, frame) | Layout DSL, not per-item verbs |
-| **Board sharing / members** | Yes (allowlist-gated) | Sharing and role updates; no member CRUD |
+| **Board sharing / members** | Yes (allowlist-gated) | Sharing, role updates and `content_item_list_roles` for the read side; no member CRUD |
 | **Export** | Yes (PDF/SVG) | No |
 | **Current user** | Derived from board owner | Yes (`user_who_am_i`) |
 | **MCP Resources** | 3 | No |

--- a/api-tracking/official-mcp-surface.json
+++ b/api-tracking/official-mcp-surface.json
@@ -1,7 +1,7 @@
 {
-  "comment": "Tool names the OFFICIAL hosted Miro MCP server (mcp.miro.com) registers, enumerated via an authenticated claude.ai connector session. The README's Official-vs-Community comparison cites len(tools). Re-enumerate monthly or on Miro announcements (bead 6kn); this needs an interactive authenticated session, so it stays manual \u2014 CI cannot do it. Diff against this file and update both it and README on drift.",
-  "enumerated": "2026-08-18",
-  "count": 63,
+  "comment": "Tool names the OFFICIAL hosted Miro MCP server (mcp.miro.com) registers, enumerated via an authenticated claude.ai connector session. The README's Official-vs-Community comparison cites len(tools). Re-enumerate monthly or on Miro announcements (bead 6kn); this needs an interactive authenticated session, so it stays manual — CI cannot do it. Diff against this file and update both it and README on drift.",
+  "enumerated": "2026-09-09",
+  "count": 61,
   "history": [
     {
       "date": "2026-08-13",
@@ -15,7 +15,12 @@
     {
       "date": "2026-08-18",
       "count": 63,
-      "note": "board_trash and space_delete removed \u2014 the surface's only hard-destructive verbs"
+      "note": "board_trash and space_delete removed — the surface's only hard-destructive verbs"
+    },
+    {
+      "date": "2026-09-09",
+      "count": 61,
+      "note": "all five code_widget_* tools removed; canvas_search, canvas_load_format_skill and content_item_list_roles added. layout_* still registered but self-describe as deprecated in favour of the canvas tools"
     }
   ],
   "tools": [
@@ -33,17 +38,15 @@
     "board_update_metadata",
     "canvas_create_from_svg",
     "canvas_get_canvas_composer_skill",
+    "canvas_load_format_skill",
     "canvas_read_as_svg",
+    "canvas_search",
     "canvas_update_from_svg",
-    "code_widget_create",
-    "code_widget_delete",
-    "code_widget_get",
-    "code_widget_list_items",
-    "code_widget_update",
     "comment_create",
     "comment_list_comments",
     "comment_reply",
     "comment_resolve",
+    "content_item_list_roles",
     "context_explore",
     "context_get",
     "diagram_create_mermaid",


### PR DESCRIPTION
Re-enumerated the hosted `mcp.miro.com` tool list on 09-09-2026 from an authenticated claude.ai connector session: 61 tools, down from 63 on 18-08-2026.

- Removed: `code_widget_create`, `code_widget_delete`, `code_widget_get`, `code_widget_list_items`, `code_widget_update`
- Added: `canvas_search`, `canvas_load_format_skill`, `content_item_list_roles`
- `layout_*` still registered, but their descriptions now say deprecated and point at `canvas_create_from_svg`

README rows corrected: tool count, code widgets (official now has none), canvas read scoping (official reads take a scope rectangle or `widget_ids`, cap 500 widgets), and board sharing (read side now covered by `content_item_list_roles`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgzxitrFxwLxpZ8GHXSTAa