### PR TITLE
ci: pin govulncheck to v1.7.0, v1.8.0 needs Go 1.26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,13 @@ jobs:
           fi
 
       - name: Run govulncheck
+        # Pinned: x/vuln v1.8.0 (09-2026) requires go >= 1.26 and fails to
+        # install under GOTOOLCHAIN=local on the 1.25 runner. v1.7.0 is the
+        # last release that builds on 1.25; the vulnerability DB is fetched
+        # at run time, so the pin does not stale the findings. Unpin when
+        # go-version moves to 1.26.
         run: |
-          go install golang.org/x/vuln/cmd/govulncheck@latest
+          go install golang.org/x/vuln/cmd/govulncheck@v1.7.0
           govulncheck ./... || echo "::warning::govulncheck found vulnerabilities (see above). Stdlib issues resolve with Go patch updates."
 
       - name: Run tests


### PR DESCRIPTION
The test job fails on every PR since x/vuln v1.8.0 shipped: `go install golang.org/x/vuln/cmd/govulncheck@latest` now resolves to a module that declares `go 1.26.0`, and the runner is Go 1.25.14 with `GOTOOLCHAIN=local`. First seen on #107 (docs-only change).

```
go: golang.org/x/vuln/cmd/govulncheck@latest: golang.org/x/vuln@v1.8.0 requires go >= 1.26.0 (running go 1.25.14; GOTOOLCHAIN=local)
```

Fix: pin to v1.7.0, the last release whose go directive is 1.25.0. The vulnerability DB is fetched at run time, so the pin does not stale the findings. Unpin when `go-version` moves to 1.26.

Ten other repos in the portfolio use the same `@latest` line and will hit this on their next CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgzxitrFxwLxpZ8GHXSTAa